### PR TITLE
Configuration for new Dashboard functionality

### DIFF
--- a/dashboard_test.cfg
+++ b/dashboard_test.cfg
@@ -1,5 +1,4 @@
 [dashboard]
 TEST_DIR=./zeeguu_api/tests/
+LOG_DIR=./
 N=5
-SUBMIT_RESULTS_URL=https://zeeguu.unibe.ch/api/dashboard/submit-test-results
-

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     dependency_links=[
             "git+https://github.com/mircealungu/zeeguu-core.git#egg=zeeguu",
             "git+https://github.com/mircealungu/python-translators.git#egg=python_translators",
+            "https://github.com/flask-dashboard/Flask-Monitoring-Dashboard/tarball/development#egg=flask_monitoring_dashboard",
         ],
     install_requires=("flask>=0.10.1",
                       "Flask-SQLAlchemy",

--- a/zeeguu_api/app.py
+++ b/zeeguu_api/app.py
@@ -25,7 +25,7 @@ app.register_blueprint(api)
 
 try:
     import dashboard
-    dashboard.config.from_file('/home/mircea/zee/http/api/dashboard.cfg')
+    dashboard.config.from_file('/home/travis/build/kloostert/Zeeguu-API/dashboard_test.cfg')
 
     # dashboard can benefit from a way of associating a request with a user id
     def get_user_id():


### PR DESCRIPTION
This should enable the new unit-test-grouping-by-endpoint functionality of the Dashboard to be used in the Zeeguu-API Travis integration.

The only thing that needs to be changed in order to build successfully on Travis is line 28 of the file `zeeguu_api/app.py`. 
This line should be changed to:
`dashboard.cofig.from_file('/home/travis/build/zeeguu-ecosystem/Zeeguu-API/dashboard_test.cfg')`

The `dashboard_test.cfg` file in this PR does not contain the SUBMIT_RESULTS_URL option, which means that the test results will not be uploaded to the live deployment of the Dashboard. This way, unwanted Travis test results will not be displayed on the live Dashboard. 
If the results should be uploaded to the live Dashboard again, simply adding the following line to the config file will do the trick:
`SUBMIT_RESULTS_URL=https://zeeguu.unibe.ch/api/dashboard/submit-test-results`