### PR TITLE
Configuration for new Dashboard functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ install: "python setup.py develop"
 
 script: 
   - "./run_tests.sh"
-  - "export DASHBOARD_CONFIG=dashboard_test.cfg"
+  - "export DASHBOARD_CONFIG=/home/travis/build/zeeguu-ecosystem/Zeeguu-API/dashboard_test.cfg"
   - "python collect_performance.py"

--- a/dashboard_test.cfg
+++ b/dashboard_test.cfg
@@ -1,5 +1,4 @@
 [dashboard]
 TEST_DIR=./zeeguu_api/tests/
+LOG_DIR=./
 N=5
-SUBMIT_RESULTS_URL=https://zeeguu.unibe.ch/api/dashboard/submit-test-results
-

--- a/dashboard_test.cfg
+++ b/dashboard_test.cfg
@@ -2,3 +2,4 @@
 TEST_DIR=./zeeguu_api/tests/
 LOG_DIR=./
 N=5
+SUBMIT_RESULTS_URL=https://zeeguu.unibe.ch/api/dashboard/submit-test-results

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     dependency_links=[
             "git+https://github.com/mircealungu/zeeguu-core.git#egg=zeeguu",
             "git+https://github.com/mircealungu/python-translators.git#egg=python_translators",
+            "https://github.com/flask-dashboard/Flask-Monitoring-Dashboard/tarball/development#egg=flask_monitoring_dashboard",
         ],
     install_requires=("flask>=0.10.1",
                       "Flask-SQLAlchemy",

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ setuptools.setup(
     description="API for Zeeguu, a project that aims to accelerate vocabulary acquisition in a second language",
     keywords=" API, second language acquisition",
     dependency_links=[
-            "git+https://github.com/mircealungu/zeeguu-core.git#egg=zeeguu",
-            "git+https://github.com/mircealungu/python-translators.git#egg=python_translators",
+            "https://github.com/zeeguu-ecosystem/Zeeguu-Core/tarball/master#egg=zeeguu",
+            "https://github.com/zeeguu-ecosystem/Python-Translators/tarball/master#egg=python_translators",
             "https://github.com/flask-dashboard/Flask-Monitoring-Dashboard/tarball/development#egg=flask_monitoring_dashboard",
         ],
     install_requires=("flask>=0.10.1",

--- a/zeeguu_api/app.py
+++ b/zeeguu_api/app.py
@@ -25,7 +25,7 @@ app.register_blueprint(api)
 
 try:
     import dashboard
-    dashboard.config.from_file('/home/travis/build/kloostert/Zeeguu-API/dashboard_test.cfg')
+    dashboard.config.from_file('/home/travis/build/zeeguu-ecosystem/Zeeguu-API/dashboard_test.cfg')
 
     # dashboard can benefit from a way of associating a request with a user id
     def get_user_id():

--- a/zeeguu_api/app.py
+++ b/zeeguu_api/app.py
@@ -25,7 +25,7 @@ app.register_blueprint(api)
 
 try:
     import dashboard
-    dashboard.config.from_file('/home/travis/build/zeeguu-ecosystem/Zeeguu-API/dashboard_test.cfg')
+    dashboard.config.from_file('/home/mircea/zee/http/api/dashboard.cfg')
 
     # dashboard can benefit from a way of associating a request with a user id
     def get_user_id():

--- a/zeeguu_api/app.py
+++ b/zeeguu_api/app.py
@@ -25,7 +25,7 @@ app.register_blueprint(api)
 
 try:
     import dashboard
-    dashboard.config.from_file('/home/mircea/zee/http/api/dashboard.cfg')
+    dashboard.config.from_file('/home/travis/build/kloostert/Zeeguu-API/dashboard_test.cfg')
 
     # dashboard can benefit from a way of associating a request with a user id
     def get_user_id():


### PR DESCRIPTION
This should enable the new unit-test-grouping-by-endpoint functionality of the Dashboard to be used in the Zeeguu-API Travis integration.

The `dashboard_test.cfg` file in this PR does not contain the SUBMIT_RESULTS_URL option, which means that the test results will not be uploaded to the live deployment of the Dashboard. 
This way, unwanted Travis test results will not be displayed on the live Dashboard.

If the results should be uploaded to the live Dashboard again, simply adding the following line to the config file will do the trick:
`SUBMIT_RESULTS_URL=https://zeeguu.unibe.ch/api/dashboard/submit-test-results`