### PR TITLE
Add A/B testing support for APIs

### DIFF
--- a/zeeguu_api/api/translate_and_bookmark.py
+++ b/zeeguu_api/api/translate_and_bookmark.py
@@ -10,7 +10,8 @@ from . import api, db_session
 from .utils.route_wrappers import cross_domain, with_session
 from .utils.json_result import json_result
 from zeeguu_core.model import Bookmark, Article
-from zeeguu_api.api.translator import minimize_context, get_all_translations
+from zeeguu_api.api.translator import (
+    minimize_context, get_all_translations, contribute_trans)
 
 
 @api.route("/get_possible_translations/<from_lang_code>/<to_lang_code>", methods=["POST"])
@@ -99,6 +100,7 @@ def contribute_translation(from_lang_code, to_lang_code):
     url = request.form.get('url', '')
     context_str = request.form.get('context', '')
     title_str = request.form.get('title', '')
+    service_name = request.form.get('servicename_translation', 'MANUAL')
 
     article_id = None
     if 'articleID' in url:
@@ -120,7 +122,11 @@ def contribute_translation(from_lang_code, to_lang_code):
                                        word_str, from_lang_code,
                                        translation_str, to_lang_code,
                                        minimal_context, url, title_str, article_id)
-
+    # Inform apimux about translation selection
+    data = {"word_str": word_str, "translation_str": translation_str,
+            "url": url, "context_size": len(context_str),
+            "service_name": service_name}
+    contribute_trans(data)
     return json_result(dict(bookmark_id=bookmark.id))
 
 

--- a/zeeguu_api/api/translate_and_bookmark.py
+++ b/zeeguu_api/api/translate_and_bookmark.py
@@ -100,6 +100,8 @@ def contribute_translation(from_lang_code, to_lang_code):
     url = request.form.get('url', '')
     context_str = request.form.get('context', '')
     title_str = request.form.get('title', '')
+    # when a translation is added by hand, the servicename_translation is None
+    # thus we set it to MANUAL
     service_name = request.form.get('servicename_translation', 'MANUAL')
 
     article_id = None

--- a/zeeguu_api/api/translator.py
+++ b/zeeguu_api/api/translator.py
@@ -20,10 +20,10 @@ from python_translators.factories.microsoft_translator_factory import (
     MicrosoftTranslatorFactory)
 from python_translators.translators.wordnik_translator import WordnikTranslator
 
-AB_TESTING = False
-if os.environ.get("ENABLE_A_B_TESTING", None) is not None:
+MULTI_LANG_TRANSLATOR_AB_TESTING = False
+if os.environ.get("MULTI_LANG_TRANSLATOR_AB_TESTING", None) is not None:
     logger.warning("A/B testing enabled!")
-    AB_TESTING = True
+    MULTI_LANG_TRANSLATOR_AB_TESTING = True
 
 
 class WordnikTranslate(BaseThirdPartyAPIService):
@@ -122,7 +122,7 @@ class MicrosoftTranslateWithoutContext(BaseThirdPartyAPIService):
 api_mux = APIMultiplexer(api_list=[
     GoogleTranslateWithContext(), GoogleTranslateWithoutContext(),
     MicrosoftTranslateWithContext(), MicrosoftTranslateWithoutContext(),
-    WordnikTranslate()], a_b_testing=AB_TESTING)
+    WordnikTranslate()], a_b_testing=MULTI_LANG_TRANSLATOR_AB_TESTING)
 
 
 def get_all_translations(data):
@@ -141,7 +141,7 @@ def get_all_translations(data):
         translations = merge_translations(translations, resp.translations)
 
     translations = filter_empty_translations(translations)
-    if AB_TESTING:
+    if MULTI_LANG_TRANSLATOR_AB_TESTING:
         # Disabling order by quality when A/B testing is enabled
         translations = order_by_quality(translations, data["query"])
 


### PR DESCRIPTION
This commit adds a way to enable A/B testing on
the APIs for quality control purposes.

Setting any value for the environment variable
ENABLE_A_B_TESTING for the zeeguu-api-core
container will now make get_all_translations
to return each API as a first result one by one.