### PR TITLE
Fix wrong count in unique articles

### DIFF
--- a/tools/report_generator/generate_report.py
+++ b/tools/report_generator/generate_report.py
@@ -399,6 +399,7 @@ def generate_active_users_table(active_user_read_ex_pd, bookmark_pd):
             bookmark_count, on="Language", how="outer"
         )
         reading_time_ex_time.loc[reading_time_ex_time["Bookmarks % Reviewed"].isna(),"Bookmarks % Reviewed"] = 0
+        reading_time_ex_time.loc[reading_time_ex_time["Total Bookmarks"].isna(),"Total Bookmarks"] = 0
     else:
         reading_time_ex_time["Bookmarks % Reviewed"] = 0
         reading_time_ex_time["Total Bookmarks"] = 0
@@ -453,9 +454,7 @@ def generate_html_page():
         )
     )
     topic_reading_time_df = data_extractor.get_topic_reading_time()
-    total_unique_articles_opened_by_users = len(
-        article_df[article_df.id.isin(user_reading_time_df.id)]
-    )
+    total_unique_articles_opened_by_users = user_reading_time_df.Language.value_counts().reset_index()['count'].sum()
     exercise_activity_df = data_extractor.get_exercise_type_activity()
     crawl_report = CrawlReport()
     crawl_report.load_crawl_report_data(DAYS_FOR_REPORT)


### PR DESCRIPTION
- Extra, when testing the issue I could see that sometimes the table in the bookmarks would display Total Bookmarks as NA, so once this is found it's set specifically to 0.

| **Before** | **After** |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/18b3c97d-0852-4125-ab91-3bf5844acb05) | ![image](https://github.com/user-attachments/assets/69f14a40-35f0-44f3-97ad-dc1898ae3335) |
| ![image](https://github.com/user-attachments/assets/4132da3b-c97e-44b3-813c-cb6c3ee5f530) | ![image](https://github.com/user-attachments/assets/a63c146a-39cb-4013-937a-4ae696fb0024) |
| **Extra Fix:** Do not show NaN in the Activity Table. |
| ![image](https://github.com/user-attachments/assets/dc921d71-d1ad-4cb8-a732-09bb1689c23c) | ![image](https://github.com/user-attachments/assets/0a859ddf-af90-4bcb-9f1f-54e30cfaa18b) |