### PR TITLE
Refactor: move session helpers from endpoints to utils

### DIFF
--- a/zeeguu/api/endpoints/sessions.py
+++ b/zeeguu/api/endpoints/sessions.py
@@ -1,25 +1,11 @@
 import flask
-from datetime import datetime
 from flask import request, make_response, current_app
 from zeeguu.core.model import Session, User
 from zeeguu.api.utils.abort_handling import make_error
+from zeeguu.api.utils.session_helpers import is_session_too_old, force_user_to_relog
 
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
 from . import api, db_session
-
-DAYS_BEFORE_EXPIRE = 30  # Days
-
-
-def is_session_too_old(session_object):
-    return (datetime.now() - session_object.last_use).days > DAYS_BEFORE_EXPIRE
-
-
-def force_user_to_relog(session_object, reason: str = ""):
-    print(
-        f"Session for user '{session_object.user_id}' was terminated. Reason: '{reason}'"
-    )
-    db_session.delete(session_object)
-    db_session.commit()
 
 
 @api.route("/session/<email>", methods=["POST"])

--- a/zeeguu/api/utils/route_wrappers.py
+++ b/zeeguu/api/utils/route_wrappers.py
@@ -43,7 +43,7 @@ def requires_session(view):
                 ),
             )
             if session_expiry_time is None or datetime.now() > session_expiry_time:
-                from zeeguu.api.endpoints.sessions import (
+                from zeeguu.api.utils.session_helpers import (
                     is_session_too_old,
                     force_user_to_relog,
                 )

--- a/zeeguu/api/utils/session_helpers.py
+++ b/zeeguu/api/utils/session_helpers.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from zeeguu.core.model.db import db
+
+DAYS_BEFORE_EXPIRE = 30  # Days
+
+
+def is_session_too_old(session_object):
+    return (datetime.now() - session_object.last_use).days > DAYS_BEFORE_EXPIRE
+
+
+def force_user_to_relog(session_object, reason: str = ""):
+    print(
+        f"Session for user '{session_object.user_id}' was terminated. Reason: '{reason}'"
+    )
+    db.session.delete(session_object)
+    db.session.commit()


### PR DESCRIPTION
## Summary
- Moves `is_session_too_old` and `force_user_to_relog` from `api/endpoints/sessions.py` to new `api/utils/session_helpers.py`
- Fixes architectural inversion where `api.utils` depended on `api.endpoints`
- `sessions.py` and `route_wrappers.py` now import from the new location

## Test plan
- [x] All 140 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)