### PR TITLE
Fix PendingRollbackError from MySQL lock wait timeout

### DIFF
--- a/zeeguu/core/content_retriever/article_downloader.py
+++ b/zeeguu/core/content_retriever/article_downloader.py
@@ -84,8 +84,12 @@ def _cache_article_tokenization(article, session):
         log(f"  - Cached tokenization for article {article.id}")
     except Exception as e:
         log(f"  - Warning: Failed to cache tokenization: {e}")
+        # Rollback to clean session state, preventing PendingRollbackError in subsequent operations
+        try:
+            session.rollback()
+        except Exception:
+            pass  # Session may already be clean
         # Don't fail the whole article download if tokenization fails
-        pass
 
 
 def should_filter_by_source_keywords(url, title):


### PR DESCRIPTION
## Summary
- Handle `OperationalError` (lock wait timeout) in `ArticleTokenizationCache.find_or_create()` - previously only `IntegrityError` was caught
- Add defensive rollback in `_cache_article_tokenization()` to ensure session is clean after any unexpected error
- This prevents `PendingRollbackError` from propagating to subsequent database operations

## Problem
When MySQL lock wait timeout (error 1205) occurred during INSERT into `article_tokenization_cache`, the SQLAlchemy session was left in a "rolled back needed" state. Subsequent operations (like lazy-loading Feed attributes) would fail with `PendingRollbackError`.

## Root Cause
The `find_or_create()` method only caught `IntegrityError` (for duplicate key race conditions), but not `OperationalError` (lock timeouts). The calling code caught the exception but didn't rollback the session.

## Test plan
- [x] All 193 tests pass
- [x] Monitor Sentry for recurrence of issue #7086416196

🤖 Generated with [Claude Code](https://claude.com/claude-code)