### PR TITLE
Skip transient connection errors from Sentry

### DIFF
--- a/zeeguu/core/content_retriever/article_downloader.py
+++ b/zeeguu/core/content_retriever/article_downloader.py
@@ -263,7 +263,13 @@ def download_from_feed(
         error_msg = str(e).lower()
         # Don't send expected HTTP errors to Sentry - these are normal for unavailable feeds
         is_http_error = any(code in error_msg for code in ['404', '403', '401', '410', '503'])
-        if is_http_error:
+        # Don't send transient connection errors to Sentry - servers go up and down
+        is_connection_error = any(term in error_msg for term in [
+            'connection refused', 'connection reset', 'connection timed out',
+            'max retries exceeded', 'newconnectionerror', 'timeout',
+            'temporary failure in name resolution', 'name or service not known'
+        ])
+        if is_http_error or is_connection_error:
             log(f"[REQUEST FAILED] Feed unavailable: {feed.title} - {e}")
         else:
             import traceback


### PR DESCRIPTION
## Summary
- Add filtering for transient connection errors (connection refused, timeouts, DNS failures) so they don't get sent to Sentry
- These errors are expected when crawling external RSS feeds - servers go up and down
- Errors are still logged locally with `[REQUEST FAILED]` for debugging if needed

## Test plan
- [x] Deploy and verify Sentry no longer receives connection errors from feed crawling
- [ ] Check logs still show `[REQUEST FAILED]` entries for these errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)