### PR TITLE
Add fix_feed tool for diagnosing and repairing broken feeds

### DIFF
--- a/tools/fix_feed.py
+++ b/tools/fix_feed.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python
+"""
+Fix Feed - diagnose, repair, or deactivate broken feeds.
+
+Finds feeds by domain, discovers working RSS URLs, and updates the feed configuration.
+
+Usage:
+    python -m tools.fix_feed --domain "lespresso.it"
+    python -m tools.fix_feed --domain "elperiodico" --dry-run
+    python -m tools.fix_feed --id 194
+    python -m tools.fix_feed --id 194 --deactivate
+    python -m tools.fix_feed --id 194 --activate
+"""
+
+import argparse
+import requests
+from urllib.parse import urlparse
+
+from zeeguu.api.app import create_app
+from zeeguu.core.model import Feed, db
+from zeeguu.core.model.url import Url
+from zeeguu.core.model.domain_name import DomainName
+
+app = create_app()
+app.app_context().push()
+
+# Common RSS feed paths to try
+RSS_PATHS = [
+    "/feed",
+    "/rss",
+    "/rss.xml",
+    "/feed.xml",
+    "/atom.xml",
+    "/feeds/posts/default",
+    "/index.xml",
+]
+
+FEED_TYPE_NAMES = {
+    0: "RSSFeed",
+    1: "NewspaperFeed",
+}
+
+
+def find_feeds_by_domain(domain_query: str):
+    """Find feeds matching a domain pattern."""
+    feeds = (
+        Feed.query
+        .join(Url, Feed.url_id == Url.id)
+        .join(DomainName, Url.domain_name_id == DomainName.id)
+        .filter(DomainName.domain_name.contains(domain_query))
+        .all()
+    )
+    return feeds
+
+
+def find_feed_by_id(feed_id: int):
+    """Find a feed by ID."""
+    return Feed.query.get(feed_id)
+
+
+def check_rss_url(url: str) -> tuple[bool, str]:
+    """Check if a URL returns valid RSS/XML content."""
+    try:
+        response = requests.get(url, timeout=10, headers={
+            'User-Agent': 'Mozilla/5.0 (compatible; ZeeguuBot/1.0)'
+        })
+        if response.status_code != 200:
+            return False, f"{response.status_code}"
+
+        content_type = response.headers.get('content-type', '').lower()
+        content_start = response.text[:500].lower()
+
+        is_xml = (
+            'xml' in content_type or
+            'rss' in content_type or
+            '<?xml' in content_start or
+            '<rss' in content_start or
+            '<feed' in content_start
+        )
+
+        if is_xml:
+            return True, "valid RSS"
+        else:
+            return False, f"not RSS (content-type: {content_type})"
+    except requests.RequestException as e:
+        return False, str(e)
+
+
+def discover_rss_feeds(base_domain: str) -> list[tuple[str, bool, str]]:
+    """Try common RSS paths and return results."""
+    results = []
+
+    # Ensure domain has scheme
+    if not base_domain.startswith('http'):
+        base_domain = f"https://{base_domain}"
+
+    # Remove trailing slash
+    base_domain = base_domain.rstrip('/')
+
+    for path in RSS_PATHS:
+        url = f"{base_domain}{path}"
+        is_valid, status = check_rss_url(url)
+        results.append((url, is_valid, status))
+
+    return results
+
+
+def deactivate_feed(feed: Feed, dry_run: bool = False):
+    """Deactivate a feed."""
+    if dry_run:
+        print(f"  [DRY RUN] Would deactivate feed {feed.id} ({feed.title})")
+        return
+
+    feed.deactivated = 1
+    db.session.commit()
+    print(f"  ✓ Deactivated feed {feed.id} ({feed.title})")
+
+
+def activate_feed(feed: Feed, dry_run: bool = False):
+    """Activate a feed."""
+    if dry_run:
+        print(f"  [DRY RUN] Would activate feed {feed.id} ({feed.title})")
+        return
+
+    feed.deactivated = 0
+    db.session.commit()
+    print(f"  ✓ Activated feed {feed.id} ({feed.title})")
+
+
+def update_feed_url(feed: Feed, new_url: str, dry_run: bool = False):
+    """Update feed to use new URL and switch to RSS type."""
+    parsed = urlparse(new_url)
+    domain_str = f"{parsed.scheme}://{parsed.netloc}"
+    path = parsed.path or "/"
+
+    if dry_run:
+        print(f"  [DRY RUN] Would update feed {feed.id}:")
+        print(f"    - New domain: {domain_str}")
+        print(f"    - New path: {path}")
+        print(f"    - New feed_type: 0 (RSSFeed)")
+        return
+
+    # Find or create domain
+    domain = DomainName.find_or_create(db.session, domain_str)
+
+    # Check if URL already exists
+    existing_url = Url.query.filter_by(
+        domain_name_id=domain.id,
+        path=path
+    ).first()
+
+    if existing_url:
+        feed.url_id = existing_url.id
+    else:
+        new_url_obj = Url(new_url, title=feed.title)
+        db.session.add(new_url_obj)
+        db.session.flush()
+        feed.url_id = new_url_obj.id
+
+    feed.feed_type = 0  # RSSFeed
+    db.session.commit()
+    print(f"  ✓ Updated feed {feed.id} to use {new_url} (RSSFeed)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fix broken feeds")
+    parser.add_argument("--domain", type=str, help="Search for feeds by domain (partial match)")
+    parser.add_argument("--id", type=int, help="Find feed by ID")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+    parser.add_argument("--auto", action="store_true", help="Automatically apply first valid RSS URL found")
+    parser.add_argument("--deactivate", action="store_true", help="Deactivate the feed(s)")
+    parser.add_argument("--activate", action="store_true", help="Activate the feed(s)")
+    args = parser.parse_args()
+
+    if args.deactivate and args.activate:
+        parser.error("Cannot use both --deactivate and --activate")
+
+    if not args.domain and not args.id:
+        parser.error("Either --domain or --id is required")
+
+    # Find feeds
+    if args.id:
+        feed = find_feed_by_id(args.id)
+        feeds = [feed] if feed else []
+    else:
+        feeds = find_feeds_by_domain(args.domain)
+
+    if not feeds:
+        print(f"No feeds found matching query")
+        return
+
+    for feed in feeds:
+        print(f"\n{'='*60}")
+        print(f"Feed: {feed.title} (id={feed.id})")
+        print(f"  Language: {feed.language.code}")
+        print(f"  Type: {FEED_TYPE_NAMES.get(feed.feed_type, f'Unknown({feed.feed_type})')}")
+        print(f"  Deactivated: {bool(feed.deactivated)}")
+        print(f"  Current URL: {feed.url.as_string() if feed.url else 'None'}")
+
+        # Handle deactivate/activate commands
+        if args.deactivate:
+            deactivate_feed(feed, args.dry_run)
+            continue
+        if args.activate:
+            activate_feed(feed, args.dry_run)
+            continue
+
+        if feed.url:
+            # Check current URL
+            current_valid, current_status = check_rss_url(feed.url.as_string())
+            status_icon = "✓" if current_valid else "✗"
+            print(f"  Current URL status: {status_icon} {current_status}")
+
+        # Get base domain for discovery
+        if feed.url:
+            parsed = urlparse(feed.url.as_string())
+            base_domain = f"{parsed.scheme}://{parsed.netloc}"
+        else:
+            continue
+
+        print(f"\n  Discovering RSS feeds at {base_domain}...")
+        results = discover_rss_feeds(base_domain)
+
+        valid_urls = []
+        for url, is_valid, status in results:
+            icon = "✓" if is_valid else "✗"
+            print(f"    {icon} {url} ({status})")
+            if is_valid:
+                valid_urls.append(url)
+
+        if not valid_urls:
+            print(f"\n  ⚠ No valid RSS feeds found. Try searching manually.")
+            continue
+
+        if args.auto and valid_urls:
+            update_feed_url(feed, valid_urls[0], args.dry_run)
+        elif valid_urls and not args.dry_run:
+            print(f"\n  Valid RSS URLs found:")
+            for i, url in enumerate(valid_urls, 1):
+                print(f"    {i}. {url}")
+
+            choice = input(f"\n  Update feed to use which URL? (1-{len(valid_urls)}, or 'n' to skip): ")
+            if choice.isdigit() and 1 <= int(choice) <= len(valid_urls):
+                update_feed_url(feed, valid_urls[int(choice) - 1], args.dry_run)
+            else:
+                print("  Skipped.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New tool `tools/fix_feed.py` for managing broken feeds
- Updated `CLAUDE.md` with Feed System documentation

## What the tool does
- Find feeds by domain or ID (with correct 3-table join)
- Check if current feed URL returns valid RSS
- Discover working RSS URLs at common paths (`/feed`, `/rss`, `/rss.xml`, etc.)
- Update feed URL and switch from NewspaperFeed (type=1) to RSSFeed (type=0)
- Deactivate/activate feeds

## Usage
```bash
# Diagnose and fix
python -m tools.fix_feed --domain "lespresso"
python -m tools.fix_feed --id 194 --auto

# Deactivate/activate
python -m tools.fix_feed --id 194 --deactivate
python -m tools.fix_feed --id 194 --activate

# Preview
python -m tools.fix_feed --domain "example" --dry-run
```

## Context
Created after debugging Sentry 404 errors from `newspaper.network` for feeds using NewspaperFeed handler. The tool automates the manual SQL work of finding feeds by domain and updating them to use working RSS URLs.

## Test plan
- [x] Tested `--domain` search
- [x] Tested `--dry-run` mode
- [x] Tested `--deactivate --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)