### PR TITLE
Mark words as learned when removed with 'learned_already' reason

### DIFF
--- a/zeeguu/api/endpoints/bookmarks_and_words.py
+++ b/zeeguu/api/endpoints/bookmarks_and_words.py
@@ -276,10 +276,17 @@ def set_user_word_exercise_preference(bookmark_id):
 @cross_domain
 @requires_session
 def set_user_word_exercise_dislike(bookmark_id):
+    from datetime import datetime
+
     bookmark = Bookmark.find(bookmark_id)
     user_word = bookmark.user_word
     user_word.user_preference = UserWordExPreference.DONT_USE_IN_EXERCISES
     user_word.update_fit_for_study(db_session)
+
+    # Check if reason is "learned_already" - if so, mark as learned
+    reason = request.form.get("reason", "")
+    if reason == "learned_already":
+        user_word.learned_time = datetime.now()
 
     BasicSRSchedule.clear_user_word_schedule(db_session, user_word)
     db_session.commit()


### PR DESCRIPTION
## Summary
- Accept optional "reason" parameter in `/dont_use_in_exercises/<bookmark_id>` endpoint
- When reason is "learned_already", set `learned_time` on user_word
- Schedule is already cleared by existing code

## Related
- Frontend PR: https://github.com/zeeguu/web/pull/853

## Test plan
- [ ] Call endpoint with reason=learned_already
- [ ] Verify user_word.learned_time is set
- [ ] Call endpoint without reason (backward compatibility)
- [ ] Verify user_word.learned_time is NOT set

🤖 Generated with [Claude Code](https://claude.com/claude-code)