### PR TITLE
Add user MWE override system

### DIFF
--- a/tools/migrations/26-01-05--add_user_mwe_override.sql
+++ b/tools/migrations/26-01-05--add_user_mwe_override.sql
@@ -1,0 +1,23 @@
+-- User MWE Override: allows users to disable incorrect MWE groupings
+-- When a user "ungroups" an MWE, we store it here so future article loads
+-- skip that mwe_group_id for this user
+--
+-- Uses sentence_hash (SHA256 of sentence text) instead of sentence_i
+-- This survives article re-ordering and naturally invalidates if sentence is edited
+--
+-- Also stores mwe_expression (the actual words) for robust matching even if
+-- mwe_group_id changes due to re-tokenization
+
+CREATE TABLE user_mwe_override (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    article_id INT NOT NULL,
+    sentence_hash VARCHAR(64) NOT NULL,
+    mwe_expression VARCHAR(255) NOT NULL,
+    disabled BOOLEAN DEFAULT TRUE,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE,
+    FOREIGN KEY (article_id) REFERENCES article(id) ON DELETE CASCADE,
+    UNIQUE KEY unique_user_article_sentence_mwe (user_id, article_id, sentence_hash, mwe_expression)
+);

--- a/zeeguu/core/model/__init__.py
+++ b/zeeguu/core/model/__init__.py
@@ -69,6 +69,7 @@ from .topic_filter import TopicFilter
 from .user_reading_session import UserReadingSession
 from .user_exercise_session import UserExerciseSession
 from .user_browsing_session import UserBrowsingSession
+from .user_mwe_override import UserMweOverride
 
 
 # bookmark scheduling

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -536,6 +536,7 @@ class Article(db.Model):
                     "context_identifier": ContextIdentifier(
                         ContextType.ARTICLE_FRAGMENT,
                         article_fragment_id=fragment.id,
+                        article_id=self.id,
                     ).as_dictionary(),
                     "formatting": fragment.formatting,
                     "tokens": (

--- a/zeeguu/core/model/user_mwe_override.py
+++ b/zeeguu/core/model/user_mwe_override.py
@@ -1,0 +1,89 @@
+import hashlib
+from datetime import datetime
+
+from zeeguu.core.model import User, Article
+from zeeguu.core.model.db import db
+
+
+class UserMweOverride(db.Model):
+    """
+    Stores user overrides for incorrect MWE (Multi-Word Expression) groupings.
+    When a user "ungroups" an MWE, we store it here so future article loads
+    skip that MWE for this user.
+
+    Uses sentence_hash (SHA256 of sentence text) instead of sentence_i.
+    This survives article re-ordering and naturally invalidates if sentence is edited.
+
+    Stores mwe_expression (the actual words like "har lavet") instead of mwe_group_id.
+    This survives re-tokenization where mwe_group_id might change.
+    """
+
+    __table_args__ = dict(mysql_collate="utf8_bin")
+    __tablename__ = "user_mwe_override"
+
+    id = db.Column(db.Integer, primary_key=True)
+
+    user_id = db.Column(db.Integer, db.ForeignKey(User.id), nullable=False)
+    user = db.relationship(User)
+
+    article_id = db.Column(db.Integer, db.ForeignKey(Article.id), nullable=False)
+    article = db.relationship(Article)
+
+    sentence_hash = db.Column(db.String(64), nullable=False)
+    mwe_expression = db.Column(db.String(255), nullable=False)
+    disabled = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.now)
+
+    def __init__(self, user_id, article_id, sentence_hash, mwe_expression, disabled=True):
+        self.user_id = user_id
+        self.article_id = article_id
+        self.sentence_hash = sentence_hash
+        self.mwe_expression = mwe_expression.lower().strip()
+        self.disabled = disabled
+        self.created_at = datetime.now()
+
+    @staticmethod
+    def compute_sentence_hash(sentence_text):
+        """Compute SHA256 hash of normalized sentence text."""
+        normalized = sentence_text.strip().lower()
+        return hashlib.sha256(normalized.encode('utf-8')).hexdigest()
+
+    @staticmethod
+    def normalize_mwe(mwe_expression):
+        """Normalize MWE expression for matching."""
+        return mwe_expression.lower().strip()
+
+    @classmethod
+    def find_or_create(cls, session, user_id, article_id, sentence_hash, mwe_expression):
+        """Find existing override or create a new one."""
+        normalized_mwe = cls.normalize_mwe(mwe_expression)
+        existing = cls.query.filter_by(
+            user_id=user_id,
+            article_id=article_id,
+            sentence_hash=sentence_hash,
+            mwe_expression=normalized_mwe
+        ).first()
+
+        if existing:
+            existing.disabled = True
+            return existing
+
+        override = cls(user_id, article_id, sentence_hash, mwe_expression)
+        session.add(override)
+        return override
+
+    @classmethod
+    def get_disabled_mwes_for_user_article(cls, user_id, article_id):
+        """Get dict mapping sentence_hash -> list of disabled mwe_expressions."""
+        overrides = cls.query.filter_by(
+            user_id=user_id,
+            article_id=article_id,
+            disabled=True
+        ).all()
+
+        result = {}
+        for o in overrides:
+            if o.sentence_hash not in result:
+                result[o.sentence_hash] = []
+            result[o.sentence_hash].append(o.mwe_expression)
+        return result


### PR DESCRIPTION
## Summary
- Adds `user_mwe_override` table to store user overrides for incorrect MWE groupings
- Indexed by sentence_hash + mwe_expression for robustness to re-ordering/re-tokenization
- Adds `/disable_mwe_grouping` endpoint
- Returns `disabled_mwe_groups` when loading article content
- Includes `article_id` in context_identifier for article fragments

## Migration
- `26-01-05--add_user_mwe_override.sql`

## Files Changed
- `zeeguu/core/model/user_mwe_override.py` - New model
- `zeeguu/api/endpoints/translation.py` - New endpoint
- `zeeguu/core/model/user_article.py` - Return disabled groups
- `zeeguu/core/model/article.py` - Include article_id in context

## Frontend PR
Requires corresponding frontend changes: zeeguu/web#858

## Test plan
- [ ] Run migration
- [ ] Translate an MWE in an article
- [ ] Call `/disable_mwe_grouping` endpoint
- [ ] Reload article - verify `disabled_mwe_groups` is returned
- [ ] Verify MWE is no longer grouped

🤖 Generated with [Claude Code](https://claude.com/claude-code)