### PR TITLE
Add anonymous account support for mobile app

### DIFF
--- a/tools/migrations/26-01-06--add_email_verified.sql
+++ b/tools/migrations/26-01-06--add_email_verified.sql
@@ -1,0 +1,4 @@
+-- Add email_verified column to user table
+-- Default TRUE for existing users (grandfathered in)
+-- Anonymous accounts will be created with FALSE
+ALTER TABLE user ADD COLUMN email_verified BOOLEAN DEFAULT TRUE;

--- a/zeeguu/api/endpoints/sessions.py
+++ b/zeeguu/api/endpoints/sessions.py
@@ -80,7 +80,7 @@ def get_anon_session(uuid):
     session = Session.create_for_user(user)
     db_session.add(session)
     db_session.commit()
-    return str(session.id)
+    return session.uuid
 
 
 @api.route("/validate")

--- a/zeeguu/core/emailer/email_confirmation.py
+++ b/zeeguu/core/emailer/email_confirmation.py
@@ -1,0 +1,15 @@
+from zeeguu.core.emailer.zeeguu_mailer import ZeeguuMailer
+
+
+def send_email_confirmation(to_email, code):
+    body = "\r\n".join([
+        "Hi there,",
+        " ",
+        "Please use this code to confirm your email: " + str(code) + ".",
+        " ",
+        "Cheers,",
+        "The Zeeguu Team"
+    ])
+
+    emailer = ZeeguuMailer('Confirm your email', body, to_email)
+    emailer.send()


### PR DESCRIPTION
## Summary

Adds support for anonymous accounts to allow mobile app users to try the app without creating an account first.

**Backend changes:**
- Add anonymous account creation with language preferences
- Add `upgrade_anon_user` endpoint to convert to full account
- Add email confirmation flow with `confirm_email` endpoint
- Add `email_verified` field to User model (migration included)
- Fix `get_anon_session` to return `session.uuid` instead of id
- Add `is_anonymous` and `bookmark_count` to user details
- Add UserLanguage creation for anonymous users with CEFR level

**Flow:**
1. Mobile users select language preferences → anonymous account created
2. Users can use app immediately
3. Upgrade prompt appears after 5+ bookmarks, 3+ days, or visiting settings
4. Upgrade includes email confirmation (3-digit code)

## Test plan
- [ ] Run migration: `ALTER TABLE user ADD COLUMN email_verified BOOLEAN DEFAULT TRUE;`
- [ ] Test anonymous account creation with `?anon=1` on web
- [ ] Test upgrade flow with email confirmation
- [ ] Test "Skip for now" option
- [ ] Test Settings page for anonymous users

🤖 Generated with [Claude Code](https://claude.com/claude-code)