### PR TITLE
Don't save exercise sessions with zero exercises

### DIFF
--- a/tools/cleanup_empty_exercise_sessions.py
+++ b/tools/cleanup_empty_exercise_sessions.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+"""
+Cleanup script to delete exercise sessions that have zero exercises.
+These empty sessions pollute activity tracking and statistics.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from zeeguu.api.app import create_app
+from zeeguu.core.model import db
+
+app = create_app()
+app.app_context().push()
+
+from zeeguu.core.model.user_exercise_session import UserExerciseSession
+from zeeguu.core.sql.learner.exercises_history import exercises_in_session
+
+
+def find_empty_sessions():
+    """Find all exercise sessions with zero exercises."""
+    all_sessions = UserExerciseSession.query.all()
+    empty_sessions = []
+
+    for session in all_sessions:
+        exercises = exercises_in_session(session.id)
+        if not exercises:
+            empty_sessions.append(session)
+
+    return empty_sessions
+
+
+def cleanup_empty_sessions(dry_run=True):
+    """Delete exercise sessions with zero exercises."""
+    empty_sessions = find_empty_sessions()
+
+    print(f"Found {len(empty_sessions)} empty exercise sessions")
+
+    if dry_run:
+        print("\nDry run - showing first 20 empty sessions:")
+        for session in empty_sessions[:20]:
+            user = session.user
+            duration_sec = session.duration / 1000 if session.duration else 0
+            print(
+                f"  Session {session.id}: user={user.name} ({user.id}), "
+                f"date={session.start_time}, duration={duration_sec:.0f}s"
+            )
+        if len(empty_sessions) > 20:
+            print(f"  ... and {len(empty_sessions) - 20} more")
+        print("\nRun with --delete to remove these sessions")
+    else:
+        for session in empty_sessions:
+            db.session.delete(session)
+        db.session.commit()
+        print(f"Deleted {len(empty_sessions)} empty sessions")
+
+
+if __name__ == "__main__":
+    dry_run = "--delete" not in sys.argv
+    cleanup_empty_sessions(dry_run=dry_run)

--- a/zeeguu/api/endpoints/exercise_sessions.py
+++ b/zeeguu/api/endpoints/exercise_sessions.py
@@ -41,7 +41,18 @@ def exercise_session_update():
 )
 @requires_session
 def exercise_session_end():
+    from zeeguu.core.sql.learner.exercises_history import exercises_in_session
+
     session = update_activity_session(UserExerciseSession, request, db_session)
+
+    # Check if any exercises were done in this session
+    exercises = exercises_in_session(session.id)
+    if not exercises:
+        # Delete empty sessions - no point in keeping them
+        db_session.delete(session)
+        db_session.commit()
+        return "OK"
+
     send_user_finished_exercise_session(session)
     return "OK"
 


### PR DESCRIPTION
## Summary
- Skip saving and emailing for sessions where no exercises were done
- Add cleanup script (`tools/cleanup_empty_exercise_sessions.py`) to remove historical empty sessions

## Background
Found ~59,000 empty exercise sessions in the database dating back to 2016. These pollute activity tracking and generate useless notifications like "Mircea: 17sec, 0words".

## Test plan
- [x] Existing tests pass
- [ ] Deploy and verify no more empty session emails
- [ ] Run cleanup script on production: `python tools/cleanup_empty_exercise_sessions.py --delete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)