### PR TITLE
Add Stanza tokenization microservice (ADR 012)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,24 @@ services:
     # taking too much memory from the host.
     restart: unless-stopped
 
+  stanza:
+    build: ./stanza_service
+    volumes:
+      - ${ZEEGUU_DATA_FOLDER}/stanza_resources:/stanza_resources
+    environment:
+      STANZA_RESOURCE_DIR: /stanza_resources
+    networks:
+      - zeeguu_backend
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 300s  # Models take time to load
+    restart: unless-stopped
+    # Stanza is CPU-intensive, limit memory to avoid OOM
+    mem_limit: 4g
+
   # yaml-anchors:
   # https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/
   zapi: &zapi_default
@@ -101,6 +119,7 @@ services:
       - elasticsearch_v8
       - readability_server
       - embedding_api
+      - stanza
     image: zeeguu/api:latest
     build: .
     ports:
@@ -119,6 +138,7 @@ services:
       ZEEGUU_CONFIG: /Zeeguu-API/api.cfg
       ZEEGUU_DATA_FOLDER: /zeeguu-data/
       ZEEGUU_RESOURCES_FOLDER: /zeeguu-data/
+      STANZA_SERVICE_URL: http://stanza:5001
       SENTRY_DSN: ${SENTRY_DSN}
       YOUTUBE_API_KEY: ${YOUTUBE_API_KEY}
       FLASK_MONITORING_DASHBOARD_CONFIG: /Zeeguu-API/fmd.cfg

--- a/stanza_service/Dockerfile
+++ b/stanza_service/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.12-slim
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy requirements first for layer caching
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY app.py gunicorn.conf.py install_models.py docker-entrypoint.sh ./
+
+# Make entrypoint executable
+RUN chmod +x docker-entrypoint.sh
+
+# Stanza models directory - mount as volume for persistence
+ENV STANZA_RESOURCE_DIR=/stanza_resources
+RUN mkdir -p $STANZA_RESOURCE_DIR
+
+# Expose port
+EXPOSE 5001
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=300s --retries=3 \
+    CMD curl -f http://localhost:5001/health || exit 1
+
+# Run with entrypoint that ensures models are downloaded
+CMD ["./docker-entrypoint.sh"]

--- a/stanza_service/app.py
+++ b/stanza_service/app.py
@@ -1,0 +1,310 @@
+"""
+Stanza Tokenization Microservice
+
+A lightweight Flask service that wraps Stanza NLP pipelines for tokenization.
+Designed to be run with gunicorn's preload_app=True for memory-efficient
+model sharing across workers via copy-on-write.
+
+Endpoints:
+- POST /tokenize - Tokenize text into structured tokens
+- POST /sentences - Extract sentences from text
+- GET /health - Health check
+- GET /languages - List supported languages
+"""
+
+import os
+import re
+import threading
+from flask import Flask, request, jsonify
+import stanza
+
+# Configuration
+STANZA_RESOURCE_DIR = os.environ.get("STANZA_RESOURCE_DIR", "/stanza_resources")
+
+# Supported languages (must match languages with downloaded models)
+SUPPORTED_LANGUAGES = [
+    "de", "es", "fr", "nl", "en", "it", "da", "pl", "sv", "ru", "no", "hu", "pt", "ro", "el"
+]
+
+# Language code mapping for Stanza compatibility
+STANZA_LANG_MAP = {
+    'no': 'nb',  # Norwegian -> Norwegian Bokmal
+}
+
+# Model types
+MODEL_TOKEN_ONLY = "token_only"
+MODEL_TOKEN_POS = "token_pos"
+MODEL_TOKEN_POS_DEP = "token_pos_dep"  # Default - includes dependency parsing
+
+PROCESSORS_MAP = {
+    MODEL_TOKEN_ONLY: "tokenize",
+    MODEL_TOKEN_POS: "tokenize,pos",
+    MODEL_TOKEN_POS_DEP: "tokenize,pos,lemma,depparse",
+}
+
+# Regex patterns
+STANZA_PARAGRAPH_DELIMITER = re.compile(r"((\s?)+\\n+)")
+PARTICLE_WITH_APOSTROPHE = re.compile(r"(\w+('|'))")
+
+# Punctuation definitions (matching Token class)
+from string import punctuation as _std_punctuation
+PUNCTUATION = "\u00bb\u00ab" + _std_punctuation + "\u2013\u2014\u201c\u2018\u201d\u201d\u2019\u201e\u00bf\u00bb\u00ab"
+LEFT_PUNCTUATION = "({#\u201e\u00bf[\u201c"
+RIGHT_PUNCTUATION = ")}\u201d]\u201d"
+
+# Global pipeline cache - loaded once in master, shared via COW after fork
+CACHED_PIPELINES = {}
+_PIPELINE_LOAD_LOCK = threading.Lock()
+
+
+def get_stanza_code(lang_code):
+    """Map language code to Stanza-compatible code."""
+    return STANZA_LANG_MAP.get(lang_code, lang_code)
+
+
+def get_pipeline(lang_code, model_type):
+    """Get or create a Stanza pipeline for the given language and model type."""
+    stanza_code = get_stanza_code(lang_code)
+    key = (stanza_code, model_type)
+
+    if key not in CACHED_PIPELINES:
+        with _PIPELINE_LOAD_LOCK:
+            if key not in CACHED_PIPELINES:
+                processors = PROCESSORS_MAP.get(model_type, PROCESSORS_MAP[MODEL_TOKEN_POS_DEP])
+                print(f"Loading Stanza pipeline: {stanza_code} with {processors}")
+                pipeline = stanza.Pipeline(
+                    lang=stanza_code,
+                    processors=processors,
+                    download_method=None,
+                    model_dir=STANZA_RESOURCE_DIR,
+                )
+                CACHED_PIPELINES[key] = pipeline
+                print(f"Loaded Stanza pipeline: {stanza_code}")
+
+    return CACHED_PIPELINES[key]
+
+
+def preload_all_models():
+    """Preload all language models. Called before forking workers."""
+    print("Preloading Stanza models for all languages...")
+    for lang_code in SUPPORTED_LANGUAGES:
+        try:
+            get_pipeline(lang_code, MODEL_TOKEN_POS_DEP)
+        except Exception as e:
+            print(f"Warning: Failed to load model for {lang_code}: {e}")
+    print(f"Preloaded {len(CACHED_PIPELINES)} Stanza pipelines")
+
+
+def tokenize_text(text, lang_code, model_type=MODEL_TOKEN_POS_DEP,
+                  flatten=True, start_token_i=0, start_sentence_i=0, start_paragraph_i=0):
+    """
+    Tokenize text using Stanza.
+
+    Returns a list of token dictionaries with structure matching the Token class.
+    """
+    pipeline = get_pipeline(lang_code, model_type)
+    doc = pipeline(text)
+
+    paragraphs = []
+    current_paragraph = []
+    s_i = 0
+
+    for sentence in doc.sentences:
+        sent_list = []
+        is_new_paragraph = False
+        accumulator = ""
+        t_i = 0
+
+        for i, token in enumerate(sentence.tokens):
+            t_details = token.to_dict()[0]
+            token_text = t_details["text"]
+
+            # Handle French/Italian particles with apostrophes (l'auteur -> l'auteur)
+            particle_match = PARTICLE_WITH_APOSTROPHE.match(token_text)
+            has_space = not ("SpaceAfter=No" in t_details.get("misc", ""))
+
+            if (particle_match
+                and particle_match.group(0) == token_text
+                and i + 1 < len(sentence.tokens)
+                and sentence.tokens[i + 1].text not in PUNCTUATION
+                and not has_space):
+                accumulator += token_text
+                continue
+
+            if accumulator:
+                token_text = accumulator + token_text
+                accumulator = ""
+
+            # Process punctuation (revert tokenizer changes)
+            token_text = token_text.replace("``", '"').replace("''", '"')
+
+            # Build token dictionary
+            token_dict = {
+                "text": token_text,
+                "par_i": len(paragraphs) + start_paragraph_i,
+                "sent_i": s_i + start_sentence_i,
+                "token_i": t_i + start_token_i,
+                "has_space": has_space,
+                "pos": t_details.get("upos"),
+                "dep": t_details.get("deprel"),
+                "head": t_details.get("head"),
+                "lemma": t_details.get("lemma"),
+                # Computed fields (matching Token class behavior)
+                "is_sent_start": t_i == 0,
+                "is_punct": token_text in PUNCTUATION or token_text in ("...", "…"),
+                "is_left_punct": token_text in LEFT_PUNCTUATION,
+                "is_right_punct": token_text in RIGHT_PUNCTUATION,
+            }
+
+            sent_list.append(token_dict)
+            t_i += 1
+
+            if STANZA_PARAGRAPH_DELIMITER.search(t_details.get("misc", "")):
+                is_new_paragraph = True
+
+        current_paragraph.append(sent_list)
+        s_i += 1
+
+        if is_new_paragraph:
+            paragraphs.append(current_paragraph)
+            current_paragraph = []
+            s_i = 0
+
+    paragraphs.append(current_paragraph)
+
+    if flatten:
+        # Flatten: paragraphs > sentences > tokens -> flat list of tokens
+        return [token for para in paragraphs for sent in para for token in sent]
+
+    return paragraphs
+
+
+def get_sentences(text, lang_code, model_type=MODEL_TOKEN_POS_DEP):
+    """Extract sentences from text."""
+    pipeline = get_pipeline(lang_code, model_type)
+    doc = pipeline(text)
+    return [" ".join([token.text for token in sent.tokens]) for sent in doc.sentences]
+
+
+# Flask application
+app = Flask(__name__)
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    """Health check endpoint."""
+    return jsonify({"status": "ok", "pipelines_loaded": len(CACHED_PIPELINES)})
+
+
+@app.route("/languages", methods=["GET"])
+def languages():
+    """List supported languages."""
+    return jsonify({
+        "languages": SUPPORTED_LANGUAGES,
+        "loaded": list(set(k[0] for k in CACHED_PIPELINES.keys()))
+    })
+
+
+@app.route("/tokenize", methods=["POST"])
+def tokenize_endpoint():
+    """
+    Tokenize text.
+
+    Request JSON:
+        {
+            "text": "Text to tokenize",
+            "language": "en",
+            "model": "token_pos_dep",  // optional, default: token_pos_dep
+            "flatten": true,           // optional, default: true
+            "start_token_i": 0,        // optional
+            "start_sentence_i": 0,     // optional
+            "start_paragraph_i": 0     // optional
+        }
+
+    Response JSON:
+        {
+            "tokens": [...]
+        }
+    """
+    data = request.get_json()
+
+    if not data:
+        return jsonify({"error": "JSON body required"}), 400
+
+    text = data.get("text", "")
+    language = data.get("language")
+    model = data.get("model", MODEL_TOKEN_POS_DEP)
+    flatten = data.get("flatten", True)
+    start_token_i = data.get("start_token_i", 0)
+    start_sentence_i = data.get("start_sentence_i", 0)
+    start_paragraph_i = data.get("start_paragraph_i", 0)
+
+    if not language:
+        return jsonify({"error": "language is required"}), 400
+
+    if language not in SUPPORTED_LANGUAGES:
+        return jsonify({"error": f"Unsupported language: {language}"}), 400
+
+    if not text:
+        return jsonify({"tokens": []})
+
+    try:
+        tokens = tokenize_text(
+            text, language, model, flatten,
+            start_token_i, start_sentence_i, start_paragraph_i
+        )
+        return jsonify({"tokens": tokens})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/sentences", methods=["POST"])
+def sentences_endpoint():
+    """
+    Extract sentences from text.
+
+    Request JSON:
+        {
+            "text": "Text with multiple sentences.",
+            "language": "en"
+        }
+
+    Response JSON:
+        {
+            "sentences": ["Text with multiple sentences."]
+        }
+    """
+    data = request.get_json()
+
+    if not data:
+        return jsonify({"error": "JSON body required"}), 400
+
+    text = data.get("text", "")
+    language = data.get("language")
+    model = data.get("model", MODEL_TOKEN_POS_DEP)
+
+    if not language:
+        return jsonify({"error": "language is required"}), 400
+
+    if language not in SUPPORTED_LANGUAGES:
+        return jsonify({"error": f"Unsupported language: {language}"}), 400
+
+    if not text:
+        return jsonify({"sentences": []})
+
+    try:
+        sentences = get_sentences(text, language, model)
+        return jsonify({"sentences": sentences})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+# Preload models when this module is loaded
+# With gunicorn's preload_app=True, this happens in master before fork
+# Workers then share models via copy-on-write memory
+preload_all_models()
+
+
+if __name__ == "__main__":
+    # For development only - production uses gunicorn
+    app.run(host="0.0.0.0", port=5001, debug=True)

--- a/stanza_service/docker-entrypoint.sh
+++ b/stanza_service/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+echo "=== Stanza Service Startup ==="
+
+# Ensure Stanza models are downloaded
+echo "Checking Stanza models..."
+python install_models.py
+
+echo "Starting Gunicorn with preload_app (models loaded in master process)..."
+exec gunicorn --config gunicorn.conf.py app:app

--- a/stanza_service/gunicorn.conf.py
+++ b/stanza_service/gunicorn.conf.py
@@ -1,0 +1,46 @@
+"""
+Gunicorn configuration for Stanza service.
+
+Key settings:
+- preload_app=True: Load Stanza models in master process before forking.
+  Workers share models via copy-on-write memory, drastically reducing RAM usage.
+- workers=2: Fewer workers since tokenization is CPU-bound (not I/O bound).
+  Adjust based on CPU cores and expected load.
+"""
+
+import os
+
+# Server socket
+bind = os.environ.get("GUNICORN_BIND", "0.0.0.0:5001")
+
+# Worker processes
+workers = int(os.environ.get("GUNICORN_WORKERS", "2"))
+threads = 1  # Single-threaded since Stanza isn't thread-safe
+
+# Preload application before forking workers
+# This loads all Stanza models ONCE in the master process
+preload_app = True
+
+# Timeouts
+timeout = 120  # Tokenization of long texts can take time
+graceful_timeout = 30
+
+# Logging
+accesslog = "-"
+errorlog = "-"
+loglevel = "info"
+
+
+def on_starting(server):
+    """Called before master process is initialized."""
+    print("Stanza service starting...")
+
+
+def post_fork(server, worker):
+    """Called after a worker has been forked."""
+    print(f"Worker {worker.pid} forked - sharing preloaded models via COW")
+
+
+def when_ready(server):
+    """Called when server is ready to accept connections."""
+    print("Stanza service ready to accept connections")

--- a/stanza_service/install_models.py
+++ b/stanza_service/install_models.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""
+Download Stanza models for all supported languages.
+
+This script downloads models only if they don't already exist,
+allowing models to persist in Docker volumes across container restarts.
+"""
+
+import os
+import stanza
+
+STANZA_RESOURCE_DIR = os.environ.get("STANZA_RESOURCE_DIR", "/stanza_resources")
+
+# Languages supported by Zeeguu (must match SUPPORTED_LANGUAGES in app.py)
+SUPPORTED_LANGUAGES = [
+    "de", "es", "fr", "nl", "en", "it", "da", "pl", "sv", "ru", "no", "hu", "pt", "ro", "el"
+]
+
+# Language code mapping for Stanza compatibility
+STANZA_LANG_MAP = {
+    'no': 'nb',  # Norwegian -> Norwegian Bokmal
+}
+
+
+def install_models():
+    """Download Stanza models only if they don't already exist."""
+    print(f"Checking Stanza models in {STANZA_RESOURCE_DIR}...")
+
+    for lang_code in SUPPORTED_LANGUAGES:
+        stanza_code = STANZA_LANG_MAP.get(lang_code, lang_code)
+        model_path = os.path.join(STANZA_RESOURCE_DIR, stanza_code)
+
+        # Check if depparse models exist (full model set)
+        depparse_path = os.path.join(model_path, "depparse")
+
+        if os.path.exists(depparse_path):
+            print(f"  {lang_code}: models exist, skipping")
+        else:
+            if os.path.exists(model_path):
+                print(f"  {lang_code}: updating models (adding lemma+depparse)...")
+            else:
+                print(f"  {lang_code}: downloading models ({stanza_code})...")
+
+            try:
+                stanza.download(
+                    stanza_code,
+                    processors="tokenize,pos,lemma,depparse",
+                    model_dir=STANZA_RESOURCE_DIR,
+                )
+                print(f"  {lang_code}: download complete")
+            except Exception as e:
+                print(f"  {lang_code}: FAILED - {e}")
+
+    print("Model installation complete.")
+
+
+if __name__ == "__main__":
+    install_models()

--- a/stanza_service/requirements.txt
+++ b/stanza_service/requirements.txt
@@ -1,0 +1,7 @@
+# Stanza service dependencies
+flask>=2.0.0
+gunicorn>=21.0.0
+stanza>=1.5.0
+
+# Stanza dependencies (PyTorch)
+torch>=2.0.0

--- a/zeeguu/core/tokenization/__init__.py
+++ b/zeeguu/core/tokenization/__init__.py
@@ -1,8 +1,10 @@
+import os
 from .token import Token
 from .zeeguu_tokenizer import TokenizerModel
 
 # Lazy imports to avoid loading stanza/torch at startup (~2s savings)
 _StanzaTokenizer = None
+_StanzaServiceClient = None
 _NLTKTokenizer = None
 
 """
@@ -18,15 +20,25 @@ TOKENIZER_MODEL = TokenizerModel.STANZA_TOKEN_POS_DEP
 # Stanza model types (duplicated here to avoid importing StanzaTokenizer)
 _STANZA_MODELS = {TokenizerModel.STANZA_TOKEN_ONLY, TokenizerModel.STANZA_TOKEN_POS, TokenizerModel.STANZA_TOKEN_POS_DEP}
 
+# Check if Stanza service is configured (microservice architecture)
+STANZA_SERVICE_URL = os.environ.get("STANZA_SERVICE_URL", "")
+
 
 def get_tokenizer(language, model):
-    global _StanzaTokenizer, _NLTKTokenizer
+    global _StanzaTokenizer, _StanzaServiceClient, _NLTKTokenizer
 
     if model in _STANZA_MODELS:
-        if _StanzaTokenizer is None:
-            from .stanza_tokenizer import StanzaTokenizer
-            _StanzaTokenizer = StanzaTokenizer
-        return _StanzaTokenizer(language, model)
+        # Use Stanza service if configured, otherwise fall back to local Stanza
+        if STANZA_SERVICE_URL:
+            if _StanzaServiceClient is None:
+                from .stanza_client import StanzaServiceClient
+                _StanzaServiceClient = StanzaServiceClient
+            return _StanzaServiceClient(language, model)
+        else:
+            if _StanzaTokenizer is None:
+                from .stanza_tokenizer import StanzaTokenizer
+                _StanzaTokenizer = StanzaTokenizer
+            return _StanzaTokenizer(language, model)
     else:
         if _NLTKTokenizer is None:
             from .nltk_tokenizer import NLTKTokenizer

--- a/zeeguu/core/tokenization/stanza_client.py
+++ b/zeeguu/core/tokenization/stanza_client.py
@@ -1,0 +1,140 @@
+"""
+HTTP client for Stanza tokenization microservice.
+
+This client provides the same interface as StanzaTokenizer but delegates
+actual tokenization to the Stanza service via HTTP.
+"""
+
+import os
+import requests
+from zeeguu.core.model.language import Language
+from zeeguu.core.tokenization.zeeguu_tokenizer import ZeeguuTokenizer, TokenizerModel
+from zeeguu.core.tokenization.token import Token
+
+# Service URL from environment variable
+STANZA_SERVICE_URL = os.environ.get("STANZA_SERVICE_URL", "")
+
+# Map TokenizerModel enum to service model strings
+MODEL_TYPE_MAP = {
+    TokenizerModel.STANZA_TOKEN_ONLY: "token_only",
+    TokenizerModel.STANZA_TOKEN_POS: "token_pos",
+    TokenizerModel.STANZA_TOKEN_POS_DEP: "token_pos_dep",
+}
+
+# Request timeout (tokenization of long texts can take time)
+REQUEST_TIMEOUT = 60  # seconds
+
+
+class StanzaServiceClient(ZeeguuTokenizer):
+    """
+    HTTP client for Stanza service.
+
+    Provides the same interface as StanzaTokenizer but makes HTTP calls
+    to the Stanza microservice instead of loading models locally.
+    """
+
+    def __init__(self, language: Language, model: TokenizerModel):
+        super().__init__(language, model)
+        self.service_url = STANZA_SERVICE_URL
+        self.model_string = MODEL_TYPE_MAP.get(model, "token_pos_dep")
+
+        if not self.service_url:
+            raise ValueError(
+                "STANZA_SERVICE_URL environment variable not set. "
+                "Set it to the Stanza service URL (e.g., http://stanza:5001)"
+            )
+
+    def is_language_supported(self, language: Language):
+        return language.code in Language.CODES_OF_LANGUAGES_THAT_CAN_BE_LEARNED
+
+    def tokenize_text(
+        self,
+        text: str,
+        as_serializable_dictionary: bool = True,
+        flatten: bool = True,
+        start_token_i: int = 0,
+        start_sentence_i: int = 0,
+        start_paragraph_i: int = 0,
+    ):
+        """
+        Tokenize text via Stanza service.
+
+        Returns tokenized text as list of token dictionaries (if as_serializable_dictionary=True)
+        or Token objects. Structure depends on flatten parameter.
+        """
+        if start_token_i is None:
+            start_token_i = 0
+        if start_sentence_i is None:
+            start_sentence_i = 0
+        if start_paragraph_i is None:
+            start_paragraph_i = 0
+
+        if not text:
+            return []
+
+        response = requests.post(
+            f"{self.service_url}/tokenize",
+            json={
+                "text": text,
+                "language": self.language.code,
+                "model": self.model_string,
+                "flatten": flatten,
+                "start_token_i": start_token_i,
+                "start_sentence_i": start_sentence_i,
+                "start_paragraph_i": start_paragraph_i,
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        tokens_data = data.get("tokens", [])
+
+        if flatten:
+            # Flat list of tokens
+            if as_serializable_dictionary:
+                return tokens_data
+            else:
+                return [self._dict_to_token(t) for t in tokens_data]
+        else:
+            # Nested structure: paragraphs > sentences > tokens
+            if as_serializable_dictionary:
+                return tokens_data
+            else:
+                return [
+                    [[self._dict_to_token(t) for t in sent] for sent in para]
+                    for para in tokens_data
+                ]
+
+    def get_sentences(self, text: str):
+        """Extract sentences from text via Stanza service."""
+        if not text:
+            return []
+
+        response = requests.post(
+            f"{self.service_url}/sentences",
+            json={
+                "text": text,
+                "language": self.language.code,
+                "model": self.model_string,
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        return data.get("sentences", [])
+
+    def _dict_to_token(self, token_dict):
+        """Convert token dictionary from service to Token object."""
+        return Token(
+            text=token_dict["text"],
+            par_i=token_dict.get("par_i"),
+            sent_i=token_dict.get("sent_i"),
+            token_i=token_dict.get("token_i"),
+            has_space=token_dict.get("has_space"),
+            pos=token_dict.get("pos"),
+            dep=token_dict.get("dep"),
+            head=token_dict.get("head"),
+            lemma=token_dict.get("lemma"),
+        )


### PR DESCRIPTION
## Summary

- Extract Stanza NLP into a separate microservice for fast API startup and memory efficiency
- Add Flask-based Stanza service with gunicorn `preload_app=True` for model sharing via COW
- Add HTTP client that implements same interface as `StanzaTokenizer`
- Update docker-compose to include stanza service

## Architecture

```
┌─────────────────┐     HTTP      ┌─────────────────────────────┐
│   Zeeguu API    │──────────────▶│     Stanza Service          │
│   (4 workers)   │  localhost    │   (gunicorn preload_app)    │
└─────────────────┘               └─────────────────────────────┘
```

## Benefits

- **Fast API startup**: API starts in seconds (no model loading)
- **Memory efficient**: Models loaded once, shared via COW across workers
- **Backward compatible**: Without `STANZA_SERVICE_URL`, falls back to local Stanza

## Files Changed

**New:**
- `stanza_service/` - Complete Flask microservice
- `zeeguu/core/tokenization/stanza_client.py` - HTTP client

**Modified:**
- `zeeguu/core/tokenization/__init__.py` - Route to client when URL configured
- `docker-compose.yml` - Add stanza service

## Test plan

- [ ] Build and start stanza service: `docker-compose build stanza && docker-compose up -d stanza`
- [ ] Verify health endpoint: `curl http://localhost:5001/health`
- [ ] Start API with service: `docker-compose up -d zapi`
- [ ] Test tokenization endpoint works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)