### PR TITLE
Add 30-minute minimum delay before words reappear in exercises

### DIFF
--- a/zeeguu/api/endpoints/exercises.py
+++ b/zeeguu/api/endpoints/exercises.py
@@ -73,6 +73,27 @@ def get_count_of_user_words_recommended_for_practice():
     return json_result(valid_count)
 
 
+@api.route("/next_word_due_time", methods=["GET"])
+@cross_domain
+@requires_session
+def get_next_word_due_time():
+    """
+    Returns when the next word is due for practice.
+    Used by frontend to show "Next word available in X minutes" messages.
+
+    Returns:
+        - null if no words are scheduled
+        - ISO timestamp string if a word is scheduled
+    """
+    user = User.find_by_id(flask.g.user_id)
+    next_time = BasicSRSchedule.next_practice_time_for_user(user)
+
+    if next_time is None:
+        return json_result(None)
+
+    return json_result(next_time.isoformat())
+
+
 @api.route(
     "/user_words_due_today",
     methods=["GET"],

--- a/zeeguu/core/word_scheduling/__init__.py
+++ b/zeeguu/core/word_scheduling/__init__.py
@@ -5,7 +5,7 @@ Word scheduling algos
 """
 
 from .basicSR.basicSR import BasicSRSchedule
-from .basicSR.four_levels_per_word import FourLevelsPerWord
+from .basicSR.four_levels_per_word import FourLevelsPerWord, MINIMUM_COOLING_INTERVAL
 
 from .basicSR.basicSR import ONE_DAY
 

--- a/zeeguu/core/word_scheduling/basicSR/basicSR.py
+++ b/zeeguu/core/word_scheduling/basicSR/basicSR.py
@@ -312,6 +312,29 @@ class BasicSRSchedule(db.Model):
                 + " \n"
             )
 
+    @classmethod
+    def next_practice_time_for_user(cls, user):
+        """
+        Returns the datetime of the next scheduled word for practice.
+        Returns None if no words are scheduled.
+        """
+        from zeeguu.core.model.bookmark import Bookmark
+
+        result = (
+            cls.query.join(UserWord)
+            .filter(UserWord.user_id == user.id)
+            .filter(UserWord.fit_for_study == 1)
+            .join(Meaning, UserWord.meaning_id == Meaning.id)
+            .join(Phrase, Meaning.origin_id == Phrase.id)
+            .filter(Phrase.language_id == user.learned_language_id)
+            .order_by(cls.next_practice_time.asc())
+            .first()
+        )
+
+        if result:
+            return result.next_practice_time
+        return None
+
 
 def priority_by_rank(user_word, schedule_map=None):
     """

--- a/zeeguu/core/word_scheduling/basicSR/four_levels_per_word.py
+++ b/zeeguu/core/word_scheduling/basicSR/four_levels_per_word.py
@@ -3,6 +3,11 @@ from datetime import datetime, timedelta
 
 MAX_LEVEL = 4
 
+# Minimum delay before a word reappears in exercises.
+# This gives users a clean "session complete" feeling instead of
+# words immediately reappearing after wrong answers or level-ups.
+MINIMUM_COOLING_INTERVAL = 30  # 30 minutes
+
 
 # Levels can be 1,2,3,4
 # When an old bookmark is migrated to the Levels scheduler the level is set to 0
@@ -71,9 +76,12 @@ class FourLevelsPerWord(BasicSRSchedule):
             ]
             self.consecutive_correct_answers = 0
 
-        # update next practice time for
+        # update next practice time
         self.cooling_interval = new_cooling_interval
-        next_practice_date = exercise_time + timedelta(minutes=new_cooling_interval)
+        # Apply minimum delay so words don't reappear immediately
+        # (but keep cooling_interval unchanged for progression logic)
+        delay_minutes = max(new_cooling_interval, MINIMUM_COOLING_INTERVAL)
+        next_practice_date = exercise_time + timedelta(minutes=delay_minutes)
         self.next_practice_time = next_practice_date
 
         db_session.add(self)


### PR DESCRIPTION
## Summary

- Words no longer reappear immediately after wrong answers or level-ups
- Adds MINIMUM_COOLING_INTERVAL (30 min) to scheduling logic
- Adds `/next_word_due_time` endpoint for frontend to show actual next practice time

## Problem

Previously, wrong answers and level-ups would schedule words for immediate practice (`cooling_interval=0`), causing a frustrating UX where users would finish an exercise session, refresh, and see "new" exercises right away.

## Solution

- Apply a 30-minute minimum delay to `next_practice_time` while keeping `cooling_interval` unchanged for progression logic
- Add API endpoint so frontend can show "Come back in 30 minutes" instead of "Come back tomorrow"

## Test plan

- [x] All scheduling tests pass
- [ ] Test exercise flow: complete exercises → verify no new exercises for 30 min
- [ ] Test `/next_word_due_time` endpoint returns correct timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)