### PR TITLE
Fix: Audio lesson intro silence caused by LLM line breaks

### DIFF
--- a/zeeguu/core/audio_lessons/prompts/meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v2.txt
+++ b/zeeguu/core/audio_lessons/prompts/meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v2.txt
@@ -10,8 +10,8 @@ Use this exact format:
     <brief scenario, also describe the relation between the man and woman>.
     Throughout the dialogue, you will hear the word [0.2 seconds]
     Man: {origin_word} [0.5 seconds]
-    Teacher: with the meaning [0.2 seconds] 
-    Teacher: {translation_word}.
+    Teacher: with the meaning [0.2 seconds]
+    Teacher: {translation_word}. [1 seconds]
 
     Create a dialogue of at least 8 lines between Man and Woman using the target word naturally.
     In between lines add one second break annotations with: [1 seconds]


### PR DESCRIPTION
## Summary
- Fix unwanted silence in audio lesson introductions caused by LLM breaking lines without voice labels
- Add duration annotation to translation word line in prompt template

## Problem
Two issues were causing silence pauses in audio lessons:

1. **Lost content**: LLM sometimes breaks the intro across multiple lines:
   ```
   Teacher: In the following conversation...
   Throughout the dialogue, you will hear the word [0.2 seconds]
   ```
   The second line lacks `Teacher:` prefix → skipped by parser, AND first line has no duration → 5s default silence

2. **5 second pause after translation**: `Teacher: {translation_word}.` had no duration → 5s silence

## Solution
- Add `_join_continuation_lines()` preprocessor to join orphan lines back to parent voice line
- Add `[1 seconds]` to translation word line in prompt template

## Test plan
- [x] Verified fix joins continuation lines correctly with problematic script
- [x] Verified parser outputs correct segments with proper durations

🤖 Generated with [Claude Code](https://claude.ai/code)