### PR TITLE
Add platform tracking to session tables and dashboard

### DIFF
--- a/tools/migrations/26-01-20--add_platform_to_session_tables.sql
+++ b/tools/migrations/26-01-20--add_platform_to_session_tables.sql
@@ -1,0 +1,9 @@
+-- Add platform tracking to session tables
+-- Platform values: 0=unknown, 1=web_desktop, 2=web_mobile, 3=ios_app, 4=android_app, 5=extension
+-- See zeeguu/core/constants.py for PLATFORM_* constants
+
+ALTER TABLE user_exercise_session ADD COLUMN platform TINYINT UNSIGNED DEFAULT NULL;
+ALTER TABLE user_reading_session ADD COLUMN platform TINYINT UNSIGNED DEFAULT NULL;
+ALTER TABLE user_browsing_session ADD COLUMN platform TINYINT UNSIGNED DEFAULT NULL;
+ALTER TABLE user_listening_session ADD COLUMN platform TINYINT UNSIGNED DEFAULT NULL;
+ALTER TABLE user_watching_session ADD COLUMN platform TINYINT UNSIGNED DEFAULT NULL;

--- a/zeeguu/api/endpoints/browsing_sessions.py
+++ b/zeeguu/api/endpoints/browsing_sessions.py
@@ -13,7 +13,10 @@ from ...core.model import UserBrowsingSession
 )
 @requires_session
 def browsing_session_start():
-    session = UserBrowsingSession._create_new_session(db_session, flask.g.user_id)
+    platform = request.form.get("platform", None)
+    if platform is not None:
+        platform = int(platform)
+    session = UserBrowsingSession._create_new_session(db_session, flask.g.user_id, platform=platform)
     return json_result(dict(id=session.id))
 
 

--- a/zeeguu/api/endpoints/exercise_sessions.py
+++ b/zeeguu/api/endpoints/exercise_sessions.py
@@ -19,7 +19,10 @@ from zeeguu.core.emailer.user_activity import (
 )
 @requires_session
 def exercise_session_start():
-    session = UserExerciseSession(flask.g.user_id, datetime.now())
+    platform = request.form.get("platform", None)
+    if platform is not None:
+        platform = int(platform)
+    session = UserExerciseSession(flask.g.user_id, datetime.now(), platform=platform)
     db_session.add(session)
     db_session.commit()
     return json_result(dict(id=session.id))

--- a/zeeguu/api/endpoints/listening_sessions.py
+++ b/zeeguu/api/endpoints/listening_sessions.py
@@ -14,8 +14,11 @@ from ...core.model import UserListeningSession
 @requires_session
 def listening_session_start():
     daily_audio_lesson_id = int(request.form.get("lesson_id", ""))
+    platform = request.form.get("platform", None)
+    if platform is not None:
+        platform = int(platform)
     session = UserListeningSession._create_new_session(
-        db_session, flask.g.user_id, daily_audio_lesson_id
+        db_session, flask.g.user_id, daily_audio_lesson_id, platform=platform
     )
     return json_result(dict(id=session.id))
 

--- a/zeeguu/api/endpoints/reading_sessions.py
+++ b/zeeguu/api/endpoints/reading_sessions.py
@@ -20,7 +20,10 @@ def reading_session_start():
     article_id = int(article_id_str)
     # reading_source: 'extension' or 'web' (optional for backwards compatibility)
     reading_source = request.form.get("reading_source", None)
-    session = UserReadingSession(flask.g.user_id, article_id, datetime.now(), reading_source)
+    platform = request.form.get("platform", None)
+    if platform is not None:
+        platform = int(platform)
+    session = UserReadingSession(flask.g.user_id, article_id, datetime.now(), reading_source, platform)
     db_session.add(session)
     db_session.commit()
     return json_result(dict(id=session.id))

--- a/zeeguu/api/endpoints/user_watching_session.py
+++ b/zeeguu/api/endpoints/user_watching_session.py
@@ -15,7 +15,10 @@ from . import api, db_session
 @requires_session
 def watching_session_start():
     video_id = int(request.form.get("video_id", ""))
-    session = UserWatchingSession(flask.g.user_id, video_id, datetime.now())
+    platform = request.form.get("platform", None)
+    if platform is not None:
+        platform = int(platform)
+    session = UserWatchingSession(flask.g.user_id, video_id, datetime.now(), platform)
     db_session.add(session)
     db_session.commit()
     return json_result(dict(id=session.id))

--- a/zeeguu/core/model/user_browsing_session.py
+++ b/zeeguu/core/model/user_browsing_session.py
@@ -29,10 +29,12 @@ class UserBrowsingSession(db.Model):
     last_action_time = db.Column(db.DateTime)
 
     is_active = db.Column(db.Boolean)
+    platform = db.Column(db.SmallInteger)
 
-    def __init__(self, user_id, current_time=None):
+    def __init__(self, user_id, current_time=None, platform=None):
         self.user_id = user_id
         self.is_active = True
+        self.platform = platform
 
         if current_time is None:
             current_time = datetime.now()
@@ -52,18 +54,19 @@ class UserBrowsingSession(db.Model):
         return cls.query.filter(cls.id == session_id).one()
 
     @staticmethod
-    def _create_new_session(db_session, user_id, current_time=None):
+    def _create_new_session(db_session, user_id, current_time=None, platform=None):
         """
         Creates a new browsing session
 
         Parameters:
         user_id = user identifier
         current_time = optional override for the current time
+        platform = platform identifier (see constants.py PLATFORM_*)
         """
         if current_time is None:
             current_time = datetime.now()
 
-        browsing_session = UserBrowsingSession(user_id, current_time)
+        browsing_session = UserBrowsingSession(user_id, current_time, platform)
         db_session.add(browsing_session)
         db_session.commit()
         return browsing_session

--- a/zeeguu/core/model/user_exercise_session.py
+++ b/zeeguu/core/model/user_exercise_session.py
@@ -30,10 +30,12 @@ class UserExerciseSession(db.Model):
     last_action_time = db.Column(db.DateTime)
 
     is_active = db.Column(db.Boolean)
+    platform = db.Column(db.SmallInteger)
 
-    def __init__(self, user_id, start_time, current_time=None):
+    def __init__(self, user_id, start_time, current_time=None, platform=None):
         self.user_id = user_id
         self.is_active = False
+        self.platform = platform
 
         # When we want to emulate an event happening in a particular moment in the past or in the future,
         #   we can provide the current_time variable to override the datetime.now()

--- a/zeeguu/core/model/user_listening_session.py
+++ b/zeeguu/core/model/user_listening_session.py
@@ -33,11 +33,13 @@ class UserListeningSession(db.Model):
     last_action_time = db.Column(db.DateTime)
 
     is_active = db.Column(db.Boolean)
+    platform = db.Column(db.SmallInteger)
 
-    def __init__(self, user_id, daily_audio_lesson_id, current_time=None):
+    def __init__(self, user_id, daily_audio_lesson_id, current_time=None, platform=None):
         self.user_id = user_id
         self.daily_audio_lesson_id = daily_audio_lesson_id
         self.is_active = True
+        self.platform = platform
 
         if current_time is None:
             current_time = datetime.now()
@@ -57,7 +59,7 @@ class UserListeningSession(db.Model):
         return cls.query.filter(cls.id == session_id).one()
 
     @staticmethod
-    def _create_new_session(db_session, user_id, daily_audio_lesson_id, current_time=None):
+    def _create_new_session(db_session, user_id, daily_audio_lesson_id, current_time=None, platform=None):
         """
         Creates a new listening session
 
@@ -65,11 +67,12 @@ class UserListeningSession(db.Model):
         user_id = user identifier
         daily_audio_lesson_id = audio lesson identifier
         current_time = optional override for the current time
+        platform = platform identifier (see constants.py PLATFORM_*)
         """
         if current_time is None:
             current_time = datetime.now()
 
-        listening_session = UserListeningSession(user_id, daily_audio_lesson_id, current_time)
+        listening_session = UserListeningSession(user_id, daily_audio_lesson_id, current_time, platform)
         db_session.add(listening_session)
         db_session.commit()
         return listening_session

--- a/zeeguu/core/model/user_reading_session.py
+++ b/zeeguu/core/model/user_reading_session.py
@@ -35,8 +35,9 @@ class UserReadingSession(db.Model):
 
     is_active = db.Column(db.Boolean)
     reading_source = db.Column(db.Enum('extension', 'web', name='reading_source_enum'))
+    platform = db.Column(db.SmallInteger)
 
-    def __init__(self, user_id, article_id, current_time=None, reading_source=None):
+    def __init__(self, user_id, article_id, current_time=None, reading_source=None, platform=None):
         self.user_id = user_id
         self.article_id = article_id
         self.is_active = True
@@ -50,6 +51,7 @@ class UserReadingSession(db.Model):
         self.last_action_time = current_time
         self.duration = 0
         self.reading_source = reading_source
+        self.platform = platform
 
     def human_readable_duration(self):
         return human_readable_duration(self.duration)

--- a/zeeguu/core/model/user_watching_session.py
+++ b/zeeguu/core/model/user_watching_session.py
@@ -30,10 +30,12 @@ class UserWatchingSession(db.Model):
     start_time = db.Column(db.DateTime)
     duration = db.Column(db.Integer)  # Duration time in milliseconds
     last_action_time = db.Column(db.DateTime)
+    platform = db.Column(db.SmallInteger)
 
-    def __init__(self, user_id, video_id, current_time=None):
+    def __init__(self, user_id, video_id, current_time=None, platform=None):
         self.user_id = user_id
         self.video_id = video_id
+        self.platform = platform
 
         if current_time is None:
             current_time = datetime.now()


### PR DESCRIPTION
## Summary
- Add `platform` column to all 5 session tables (exercise, reading, browsing, listening, watching)
- Update session models and endpoints to accept optional `platform` parameter
- Add "Platform Usage" section to admin dashboard (`/user_stats/dashboard`) showing active users and event counts by platform

## Details

**Migration:** `tools/migrations/26-01-20--add_platform_to_session_tables.sql`

**Updated endpoints** (all now accept optional `platform` parameter):
- `/exercise_session_start`
- `/reading_session_start`
- `/browsing_session_start`
- `/listening_session_start`
- `/watching_session_start`

**Dashboard:** Uses existing `user_activity_data.platform` to show platform breakdown immediately. As sessions start recording platform data, this can be enhanced further.

## Test plan
- [x] All existing tests pass (16 passed)
- [ ] Run migration on database
- [ ] Verify dashboard shows Platform Usage section
- [ ] Update frontend to send platform when starting sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)