### PR TITLE
Distinguish declared-known from don't-use-in-exercises

### DIFF
--- a/tools/migrations/26-01-27--add_user_word_interaction_history.sql
+++ b/tools/migrations/26-01-27--add_user_word_interaction_history.sql
@@ -1,0 +1,9 @@
+CREATE TABLE user_word_interaction_history (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_word_id INT NOT NULL,
+    interaction_type VARCHAR(50) NOT NULL,
+    event_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_word_id) REFERENCES user_word(id),
+    INDEX idx_user_word (user_word_id),
+    INDEX idx_interaction_type (interaction_type)
+) CHARACTER SET utf8mb4;

--- a/zeeguu/core/bookmark_quality/fit_for_study.py
+++ b/zeeguu/core/bookmark_quality/fit_for_study.py
@@ -7,12 +7,9 @@ def fit_for_study(user_word):
     preference = int(user_word.user_preference or 0)
 
     return (
-        (
-            quality_meaning(user_word)
-            or preference == UserWordExPreference.USE_IN_EXERCISES
-        )
-        and not preference == UserWordExPreference.DONT_USE_IN_EXERCISES
-    )
+        quality_meaning(user_word)
+        or preference == UserWordExPreference.USE_IN_EXERCISES
+    ) and preference >= UserWordExPreference.NO_PREFERENCE
 
 
 def feedback_prevents_further_study(exercise_log):

--- a/zeeguu/core/model/__init__.py
+++ b/zeeguu/core/model/__init__.py
@@ -53,6 +53,7 @@ from .exercise_source import ExerciseSource
 
 # user logging
 from .user_activitiy_data import UserActivityData
+from .user_word_interaction_history import UserWordInteractionHistory
 
 # teachers and cohorts
 
@@ -99,3 +100,6 @@ from .user_listening_session import UserListeningSession
 
 # grammar correction tracking
 from .grammar_correction_log import GrammarCorrectionLog, CorrectionFieldType
+
+# translation validation
+from .validation_log import ValidationLog

--- a/zeeguu/core/model/bookmark_user_preference.py
+++ b/zeeguu/core/model/bookmark_user_preference.py
@@ -1,6 +1,17 @@
 class UserWordExPreference(object):
-    # Defines user preference to use worrd
-    # in exercises
-    DONT_USE_IN_EXERCISES = -1
+    # Defines user preference to use word in exercises
+    BAD_TRANSLATION = -100  # bad translation - permanent exclusion
+    DECLARED_KNOWN = -6  # freshly declared known, erodes with re-translations (-6 → -4 → -2 → 0)
+    DONT_USE_IN_EXERCISES = -1  # other reasons - permanent exclusion
     NO_PREFERENCE = 0
-    USE_IN_EXERCISES = 1
+    USE_IN_EXERCISES = 1  # user explicitly opted in (overrides quality checks)
+
+    @classmethod
+    def is_declared_known(cls, preference):
+        """Declared known uses even negative values: -6, -4, -2"""
+        return (
+            preference is not None
+            and preference <= -2
+            and preference >= -6
+            and preference % 2 == 0
+        )

--- a/zeeguu/core/model/user_word_interaction_history.py
+++ b/zeeguu/core/model/user_word_interaction_history.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+
+from zeeguu.core.model.db import db
+from zeeguu.core.model.user_word import UserWord
+
+
+class UserWordInteractionHistory(db.Model):
+    __tablename__ = "user_word_interaction_history"
+
+    id = Column(Integer, primary_key=True)
+
+    user_word_id = Column(Integer, ForeignKey(UserWord.id), nullable=False)
+    user_word = relationship(UserWord)
+
+    interaction_type = Column(String(50), nullable=False)
+    event_time = Column(DateTime, nullable=False, default=datetime.now)
+
+    # Interaction type constants
+    TRANSLATED = "translated"
+    DECLARED_KNOWN = "declared_known"
+    BAD_TRANSLATION = "bad_translation"
+    MANUAL_ADDITION = "manual_addition"
+
+    def __init__(self, user_word, interaction_type):
+        self.user_word = user_word
+        self.interaction_type = interaction_type
+        self.event_time = datetime.now()
+
+    @classmethod
+    def log(cls, session, user_word, interaction_type):
+        entry = cls(user_word, interaction_type)
+        session.add(entry)


### PR DESCRIPTION
## Summary

- Add `DECLARED_KNOWN = -6` and `BAD_TRANSLATION = -100` preference values to distinguish why a word was removed from exercises
- `DECLARED_KNOWN` erodes with re-translations: each re-translation adds +2 (so -6 → -4 → -2 → 0). After 3 re-translations the word returns to exercises
- `BAD_TRANSLATION` is permanent (-100), never auto-clears
- `DONT_USE_IN_EXERCISES` (-1) remains for "other" reasons, also permanent
- Manual add immediately clears declared-known state
- Does NOT set `learned_time` for "I know this word" (known != learned)
- New `user_meaning_interaction_history` table tracks semantic events (declared_known, retranslated, undeclared, bad_translation)
- Fixes missing `ValidationLog` import in `__init__.py` (unrelated pre-existing issue)

## Test plan

- [ ] Run migration `26-01-27--add_user_meaning_interaction_history.sql`
- [ ] Mark a word as "I know this word" → verify preference = -6, word removed from exercises, NOT in Learned tab
- [ ] Re-translate the same word 3 times → verify word reappears in Learning (preference = 0)
- [ ] Mark a word as "Bad translation" → verify preference = -100, permanent
- [ ] Manually add a declared-known word → verify immediate clear (preference = 0)
- [ ] Check `user_meaning_interaction_history` table has events logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)