### PR TITLE
Stop sending feed connection timeouts to Sentry

### DIFF
--- a/zeeguu/core/feed_handler/rssfeed.py
+++ b/zeeguu/core/feed_handler/rssfeed.py
@@ -68,10 +68,8 @@ class RSSFeed(FeedHandler):
                 )
                 feed_items.append(new_item_data_dict)
         except requests.exceptions.ConnectTimeout as e:
-            msg = f"Connection timeout when trying to connect to {self.url}"
-            from sentry_sdk import capture_message
-
-            print(msg)
-            capture_message(msg)
+            # Don't send to Sentry - connection timeouts are expected operational issues
+            # The calling code in article_downloader.py logs these appropriately
+            log(f"Connection timeout when trying to connect to {self.url}")
 
         return feed_items


### PR DESCRIPTION
## Summary
- Remove `capture_message` for connection timeouts in `rssfeed.py`
- These are expected operational issues, not bugs
- Feed errors are already tracked in the crawl report where they belong
- Reduces Sentry noise (fixes ZEEGUU-API-WF)

## Test plan
- [x] Code review
- [ ] Verify ZEEGUU-API-WF stops getting new events after deploy

🤖 Generated with [Claude Code](https://claude.ai/code)