### PR TITLE
Add report exercise issue feature (backend)

### DIFF
--- a/tools/migrations/26-02-13--add_exercise_report.sql
+++ b/tools/migrations/26-02-13--add_exercise_report.sql
@@ -1,0 +1,15 @@
+CREATE TABLE exercise_report (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    bookmark_id INT NOT NULL,
+    exercise_source_id INT NOT NULL,
+    reason ENUM('word_not_shown', 'context_confusing', 'wrong_translation', 'context_wrong', 'other') NOT NULL,
+    comment TEXT DEFAULT NULL,
+    context_used TEXT DEFAULT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    resolved BOOLEAN DEFAULT FALSE,
+    FOREIGN KEY (user_id) REFERENCES user(id),
+    FOREIGN KEY (bookmark_id) REFERENCES bookmark(id),
+    FOREIGN KEY (exercise_source_id) REFERENCES exercise_source(id),
+    UNIQUE KEY unique_user_bookmark_source (user_id, bookmark_id, exercise_source_id)
+);

--- a/zeeguu/core/model/__init__.py
+++ b/zeeguu/core/model/__init__.py
@@ -51,6 +51,7 @@ from .search_subscription import SearchSubscription
 from .exercise import Exercise
 from .exercise_outcome import ExerciseOutcome
 from .exercise_source import ExerciseSource
+from .exercise_report import ExerciseReport
 
 # user logging
 from .user_activitiy_data import UserActivityData

--- a/zeeguu/core/model/exercise_report.py
+++ b/zeeguu/core/model/exercise_report.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+
+from zeeguu.core.model.db import db
+
+
+class ExerciseReport(db.Model):
+    """
+    User reports for broken or problematic exercises.
+
+    Used to flag issues like missing word in cloze, bad translations,
+    confusing context, etc.
+    """
+
+    __tablename__ = "exercise_report"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    bookmark_id = db.Column(db.Integer, db.ForeignKey("bookmark.id"), nullable=False)
+    exercise_source_id = db.Column(
+        db.Integer, db.ForeignKey("exercise_source.id"), nullable=False
+    )
+    reason = db.Column(
+        db.Enum(
+            "word_not_shown",
+            "context_confusing",
+            "wrong_translation",
+            "context_wrong",
+            "other",
+        ),
+        nullable=False,
+    )
+    comment = db.Column(db.Text, nullable=True)
+    context_used = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.now)
+    resolved = db.Column(db.Boolean, default=False)
+
+    user = db.relationship("User")
+    bookmark = db.relationship("Bookmark", backref="exercise_reports")
+    exercise_source = db.relationship("ExerciseSource")
+
+    def __init__(
+        self, user, bookmark, exercise_source, reason, comment=None, context_used=None
+    ):
+        self.user_id = user.id
+        self.bookmark_id = bookmark.id
+        self.exercise_source_id = exercise_source.id
+        self.reason = reason
+        self.comment = comment
+        self.context_used = context_used
+
+    @classmethod
+    def create(
+        cls, session, user, bookmark, exercise_source, reason, comment=None, context_used=None
+    ):
+        report = cls(user, bookmark, exercise_source, reason, comment, context_used)
+        session.add(report)
+        session.commit()
+        return report
+
+    @classmethod
+    def find_by_user_bookmark_source(cls, user_id, bookmark_id, exercise_source_id):
+        return cls.query.filter_by(
+            user_id=user_id,
+            bookmark_id=bookmark_id,
+            exercise_source_id=exercise_source_id,
+        ).first()
+
+    @classmethod
+    def count_for_bookmark(cls, bookmark_id):
+        return cls.query.filter_by(bookmark_id=bookmark_id, resolved=False).count()
+
+    def as_dictionary(self):
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "bookmark_id": self.bookmark_id,
+            "exercise_source_id": self.exercise_source_id,
+            "reason": self.reason,
+            "comment": self.comment,
+            "context_used": self.context_used,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "resolved": self.resolved,
+        }


### PR DESCRIPTION
## Summary
- Add `exercise_report` table migration with FK to `exercise_source`
- Create `ExerciseReport` model with reason enum
- Add `POST /report_exercise_issue` API endpoint
- Unique constraint prevents duplicate reports per user/bookmark/source

## Reason categories
- `word_not_shown` - cloze exercise shows no gap
- `context_confusing` - context sentence is unclear
- `wrong_translation` - translation appears incorrect
- `context_wrong` - context doesn't match the word
- `other` - free text comment

## Test plan
- [ ] Run migration on database
- [ ] Test endpoint with curl/Postman
- [ ] Verify duplicate prevention works

🤖 Generated with [Claude Code](https://claude.ai/code)