### PR TITLE
Fix article extraction to use readability-cleaned HTML

### DIFF
--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -1350,8 +1350,8 @@ class Article(db.Model):
                 canonical_url, html_content=html_content
             )
 
-            # newspaper Article objects use .html, not .htmlContent
-            html_content = np_article.html
+            # Use readability-cleaned HTML (not raw np_article.html)
+            html_content = np_article.htmlContent
             article_text = np_article.text  # Full article text from readability server
             title = np_article.title
             authors = ", ".join(np_article.authors or [])


### PR DESCRIPTION
## Summary
- `Article.find_or_create()` was using `np_article.html` (raw newspaper HTML) instead of `np_article.htmlContent` (readability server output)
- This caused navigation menus, headers, and footers to appear as bullet-point lists at the top of shared articles
- One-line fix: the readability server was doing its job, we just weren't using its output

## Test plan
- [ ] Delete a problematic shared article from DB, re-share the URL, verify nav bullet points are gone
- [ ] Verify normal article creation from feeds still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)