### PR TITLE
Fix: rename 'username' to 'name' in account creation endpoints (api side, web#955)

### DIFF
--- a/zeeguu/api/endpoints/accounts.py
+++ b/zeeguu/api/endpoints/accounts.py
@@ -43,7 +43,7 @@ def add_user(email):
     """
 
     password = request.form.get("password")
-    username = request.form.get("username")
+    name = request.form.get("name")
     learned_language_code = request.form.get(
         "learned_language", "de"
     )  # default language; it's changed by the ui later
@@ -59,7 +59,7 @@ def add_user(email):
     try:
         new_user = create_account(
             db_session,
-            username,
+            name,
             password,
             invite_code,
             email,
@@ -105,13 +105,13 @@ def add_basic_user(email):
     from ...core.account_management.user_account_creation import create_basic_account
 
     password = request.form.get("password")
-    username = request.form.get("username")
+    name = request.form.get("name")
     invite_code = request.form.get("invite_code")
     platform = request.form.get("platform")
 
     try:
         new_user = create_basic_account(
-            db_session, username, password, invite_code, email, creation_platform=platform
+            db_session, name, password, invite_code, email, creation_platform=platform
         )
         new_session = Session.create_for_user(new_user)
         db_session.add(new_session)

--- a/zeeguu/api/test/test_account_creation.py
+++ b/zeeguu/api/test/test_account_creation.py
@@ -10,14 +10,14 @@ TEST_USER = "test_user"
 
 
 def test_add_user(client):
-    test_user_data = dict(password=TEST_PASS, username=TEST_USER)
+    test_user_data = dict(password=TEST_PASS, name=TEST_USER)
 
     response = client.post(f"/add_user/{TEST_EMAIL}", data=test_user_data)
     assert str(response.data)
 
 
 def test_cant_add_same_email_twice(client):
-    test_user_data = dict(password=TEST_PASS, username=TEST_USER)
+    test_user_data = dict(password=TEST_PASS, name=TEST_USER)
     response = client.post(f"/add_user/{TEST_EMAIL}", data=test_user_data)
     assert str(response.data)
 
@@ -28,19 +28,19 @@ def test_cant_add_same_email_twice(client):
 
 
 def test_create_user_returns_400_if_password_too_short(client):
-    form_data = dict(username="gigi", password="2sh", invite_code="test")
+    form_data = dict(name="gigi", password="2sh", invite_code="test")
     response = client.post("/add_user/i@i.la", data=form_data)
     assert response.status_code == 400
 
 
 def test_create_user_returns_400_if_password_absent(client):
-    form_data = dict(username="gigi", invite_code="test")
+    form_data = dict(name="gigi", invite_code="test")
     response = client.post("/add_user/i@i.la", data=form_data)
     assert response.status_code == 400
 
 
 def test_create_user_returns_400_if_password_not_given(client):
-    form_data = dict(username="gigi")
+    form_data = dict(name="gigi")
     response = client.post("/add_user/i@i.la", data=form_data)
     assert response.status_code == 400
 
@@ -103,6 +103,6 @@ def test_reset_password_returns_400_invalid_code(client):
 
 
 def _create_test_user(client):
-    test_user_data = dict(password=TEST_PASS, username=TEST_USER)
+    test_user_data = dict(password=TEST_PASS, name=TEST_USER)
 
     _ = client.post(f"/add_user/{TEST_EMAIL}", data=test_user_data)

--- a/zeeguu/core/account_management/user_account_creation.py
+++ b/zeeguu/core/account_management/user_account_creation.py
@@ -30,7 +30,7 @@ def valid_invite_code(invite_code):
 # TODO: delete after the new onboarding of Iga is done
 def create_account(
     db_session,
-    username,
+    name,
     password,
     invite_code,
     email,
@@ -62,7 +62,7 @@ def create_account(
 
         new_user = User(
             email,
-            username,
+            name,
             password,
             invitation_code=invite_code,
             learned_language=learned_language,
@@ -93,7 +93,7 @@ def create_account(
 
         db_session.commit()
 
-        send_new_user_account_email(username, invite_code, cohort_name)
+        send_new_user_account_email(name, invite_code, cohort_name)
 
         # Send email verification code
         code = UniqueCode(email)
@@ -111,7 +111,7 @@ def create_account(
         raise Exception("Could not create the account")
 
 
-def create_basic_account(db_session, username, password, invite_code, email, creation_platform=None):
+def create_basic_account(db_session, name, password, invite_code, email, creation_platform=None):
     cohort_name = ""
     if password is None or len(password) < 4:
         raise Exception("Password should be at least 4 characters long")
@@ -130,7 +130,7 @@ def create_basic_account(db_session, username, password, invite_code, email, cre
 
     try:
         new_user = User(
-            email, username, password, invitation_code=invite_code, creation_platform=creation_platform
+            email, name, password, invitation_code=invite_code, creation_platform=creation_platform
         )
         new_user.email_verified = False  # Require email verification
 
@@ -143,7 +143,7 @@ def create_basic_account(db_session, username, password, invite_code, email, cre
 
         db_session.commit()
 
-        send_new_user_account_email(username, invite_code, cohort_name)
+        send_new_user_account_email(name, invite_code, cohort_name)
 
         # Send email verification code
         code = UniqueCode(email)


### PR DESCRIPTION
## Summary

Fixes the API-side of the naming inconsistency described in zeeguu/web#955.

The `add_user` and `add_basic_user` endpoints were reading the user's display name from the `username` form field, and passing it through `create_account()` / `create_basic_account()` as a parameter also named `username`. This was inconsistent with:
- `User.__init__` and `User.name` (the model uses `name`)
- The `name` database column
- The `user_settings` endpoint which reads `data.get("name", None)`
- The `get_user_details` API response which returns `name`

**Changes:**
- `accounts.py`: `request.form.get("username")` → `request.form.get("name")` in both `add_user` and `add_basic_user`
- `user_account_creation.py`: parameter `username` → `name` in `create_account()` and `create_basic_account()`
- `test_account_creation.py`: update form data keys from `username=` to `name=`

**Must be merged together with the matching web-side PR:** zeeguu/web#996

## Commits

1. **Fix commit** (`5263cf4`): Rename the form parameter and internal variable from `username` to `name` throughout the account creation flow, including tests.