### PR TITLE
Fix: add show_reading_timer user preference to API

### DIFF
--- a/zeeguu/api/endpoints/user_preferences.py
+++ b/zeeguu/api/endpoints/user_preferences.py
@@ -94,6 +94,16 @@ def save_user_preferences():
         show_mwe_hints.value = show_mwe_hints_value
         db_session.add(show_mwe_hints)
 
+    show_reading_timer_value = data.get(UserPreference.SHOW_READING_TIMER, None)
+    if show_reading_timer_value is not None:
+        show_reading_timer = UserPreference.find_or_create(
+            db_session,
+            user,
+            UserPreference.SHOW_READING_TIMER,
+        )
+        show_reading_timer.value = show_reading_timer_value
+        db_session.add(show_reading_timer)
+
     db_session.add(user)
     db_session.commit()
     return "OK"

--- a/zeeguu/core/model/user_preference.py
+++ b/zeeguu/core/model/user_preference.py
@@ -42,6 +42,7 @@ class UserPreference(db.Model):
     MAX_WORDS_TO_SCHEDULE = "max_words_to_schedule"
     FILTER_DISTURBING_CONTENT = "filter_disturbing_content"  # Filter violence/death/tragedy articles
     SHOW_MWE_HINTS = "show_mwe_hints"  # Show hints for multi-word expressions
+    SHOW_READING_TIMER = "show_reading_timer"  # Show timer in reader and exercises
 
     def __init__(self, user: User, key=None, value=None):
         self.user = user


### PR DESCRIPTION
## Summary

API-side support for zeeguu/web#965.

Adds the `show_reading_timer` preference so the frontend can persist the timer visibility setting across sessions.

## Changes

- `user_preference.py`: add `SHOW_READING_TIMER = "show_reading_timer"` constant
- `user_preferences.py`: handle `show_reading_timer` in `save_user_preferences` endpoint (same pattern as `show_mwe_hints`)

---

To discuss this fix, find this session at https://claude.ai/code