### PR TITLE
Credit activity-session streak to the session's language, not user.learned_language

### DIFF
--- a/tools/migrations/26-04-07--add_language_id_to_exercise_and_browsing_sessions.sql
+++ b/tools/migrations/26-04-07--add_language_id_to_exercise_and_browsing_sessions.sql
@@ -1,14 +1,6 @@
--- Capture the user's learned_language_id at the moment an exercise or
--- browsing session is created, so streak attribution doesn't depend on
--- the user's *current* learned_language at update time. Without this,
--- a tail update for a session started in language A that arrives after
--- the user toggles to language B would credit B's streak. Listening,
--- reading, and watching sessions don't need this column because they
--- can derive language from their content (daily_audio_lesson, article,
--- video). See activity_sessions._session_language.
---
--- Nullable so existing rows backfill as NULL; the helper falls back to
--- user.learned_language for old rows.
+-- Snapshot user.learned_language_id at session start so a late tail-update
+-- can't be re-credited after the user switches languages. Nullable; old
+-- rows fall back to user.learned_language. See activity_sessions._session_language.
 
 ALTER TABLE user_exercise_session ADD COLUMN language_id INT DEFAULT NULL;
 ALTER TABLE user_browsing_session ADD COLUMN language_id INT DEFAULT NULL;

--- a/tools/migrations/26-04-07--add_language_id_to_exercise_and_browsing_sessions.sql
+++ b/tools/migrations/26-04-07--add_language_id_to_exercise_and_browsing_sessions.sql
@@ -1,0 +1,14 @@
+-- Capture the user's learned_language_id at the moment an exercise or
+-- browsing session is created, so streak attribution doesn't depend on
+-- the user's *current* learned_language at update time. Without this,
+-- a tail update for a session started in language A that arrives after
+-- the user toggles to language B would credit B's streak. Listening,
+-- reading, and watching sessions don't need this column because they
+-- can derive language from their content (daily_audio_lesson, article,
+-- video). See activity_sessions._session_language.
+--
+-- Nullable so existing rows backfill as NULL; the helper falls back to
+-- user.learned_language for old rows.
+
+ALTER TABLE user_exercise_session ADD COLUMN language_id INT DEFAULT NULL;
+ALTER TABLE user_browsing_session ADD COLUMN language_id INT DEFAULT NULL;

--- a/zeeguu/api/endpoints/browsing_sessions.py
+++ b/zeeguu/api/endpoints/browsing_sessions.py
@@ -18,12 +18,12 @@ def browsing_session_start():
     platform = request.form.get("platform", None)
     if platform is not None:
         platform = int(platform)
-    # Capture the user's current learned_language so streak attribution
-    # survives a later language toggle (see activity_sessions._session_language).
     user = User.find_by_id(flask.g.user_id)
-    language_id = user.learned_language_id if user else None
     session = UserBrowsingSession._create_new_session(
-        db_session, flask.g.user_id, platform=platform, language_id=language_id
+        db_session,
+        flask.g.user_id,
+        platform=platform,
+        language_id=user.learned_language_id,
     )
     return json_result(dict(id=session.id))
 

--- a/zeeguu/api/endpoints/browsing_sessions.py
+++ b/zeeguu/api/endpoints/browsing_sessions.py
@@ -5,7 +5,7 @@ from . import api, db_session
 from zeeguu.api.utils import requires_session, json_result
 from zeeguu.api.utils.route_wrappers import cross_domain
 from .helpers.activity_sessions import update_activity_session
-from ...core.model import UserBrowsingSession
+from ...core.model import User, UserBrowsingSession
 
 
 @api.route(
@@ -18,7 +18,13 @@ def browsing_session_start():
     platform = request.form.get("platform", None)
     if platform is not None:
         platform = int(platform)
-    session = UserBrowsingSession._create_new_session(db_session, flask.g.user_id, platform=platform)
+    # Capture the user's current learned_language so streak attribution
+    # survives a later language toggle (see activity_sessions._session_language).
+    user = User.find_by_id(flask.g.user_id)
+    language_id = user.learned_language_id if user else None
+    session = UserBrowsingSession._create_new_session(
+        db_session, flask.g.user_id, platform=platform, language_id=language_id
+    )
     return json_result(dict(id=session.id))
 
 

--- a/zeeguu/api/endpoints/exercise_sessions.py
+++ b/zeeguu/api/endpoints/exercise_sessions.py
@@ -1,6 +1,6 @@
 import flask
 
-from zeeguu.core.model import UserExerciseSession
+from zeeguu.core.model import User, UserExerciseSession
 
 from zeeguu.api.utils.route_wrappers import requires_session, cross_domain
 from zeeguu.api.utils.json_result import json_result
@@ -23,7 +23,13 @@ def exercise_session_start():
     platform = request.form.get("platform", None)
     if platform is not None:
         platform = int(platform)
-    session = UserExerciseSession(flask.g.user_id, datetime.now(), platform=platform)
+    # Capture the user's current learned_language so streak attribution
+    # survives a later language toggle (see activity_sessions._session_language).
+    user = User.find_by_id(flask.g.user_id)
+    language_id = user.learned_language_id if user else None
+    session = UserExerciseSession(
+        flask.g.user_id, datetime.now(), platform=platform, language_id=language_id
+    )
     db_session.add(session)
     db_session.commit()
     return json_result(dict(id=session.id))

--- a/zeeguu/api/endpoints/exercise_sessions.py
+++ b/zeeguu/api/endpoints/exercise_sessions.py
@@ -23,12 +23,12 @@ def exercise_session_start():
     platform = request.form.get("platform", None)
     if platform is not None:
         platform = int(platform)
-    # Capture the user's current learned_language so streak attribution
-    # survives a later language toggle (see activity_sessions._session_language).
     user = User.find_by_id(flask.g.user_id)
-    language_id = user.learned_language_id if user else None
     session = UserExerciseSession(
-        flask.g.user_id, datetime.now(), platform=platform, language_id=language_id
+        flask.g.user_id,
+        datetime.now(),
+        platform=platform,
+        language_id=user.learned_language_id,
     )
     db_session.add(session)
     db_session.commit()

--- a/zeeguu/api/endpoints/helpers/activity_sessions.py
+++ b/zeeguu/api/endpoints/helpers/activity_sessions.py
@@ -7,6 +7,7 @@ import flask
 from datetime import datetime
 
 from zeeguu.core.model import User
+from zeeguu.core.model.language import Language
 from zeeguu.core.model.user_language import UserLanguage
 
 
@@ -21,7 +22,7 @@ def update_activity_session(session_class, request, db_session):
     db_session.add(session)
 
     if duration >= MIN_STREAK_DURATION_MS:
-        _update_streak(db_session)
+        _update_streak(db_session, session)
 
     db_session.commit()
 
@@ -31,10 +32,47 @@ def update_activity_session(session_class, request, db_session):
 MIN_STREAK_DURATION_MS = 120_000  # 2 minutes in milliseconds (frontend sends ms)
 
 
-def _update_streak(db_session):
+def _session_language(session):
+    """Return the Language this activity session belongs to, or None.
+
+    The streak must be credited to the language of the *content* the user
+    is practicing, not to the user's currently-selected `learned_language`.
+    Otherwise, a tail update for a session in language A that arrives after
+    the user has switched to language B incorrectly credits B's streak.
+
+    Listening, reading, and watching sessions all carry a content reference
+    (daily audio lesson / article / video) that knows its own language.
+    Exercise and browsing sessions have no content link, so callers fall
+    back to `user.learned_language` for those.
+    """
+    daily_audio_lesson = getattr(session, "daily_audio_lesson", None)
+    if daily_audio_lesson is not None:
+        return Language.find_by_id(daily_audio_lesson.language_id)
+
+    article = getattr(session, "article", None)
+    if article is not None:
+        return Language.find_by_id(article.language_id)
+
+    video = getattr(session, "video", None)
+    if video is not None:
+        return Language.find_by_id(video.language_id)
+
+    return None
+
+
+def _update_streak(db_session, session):
     user = User.find_by_id(flask.g.user_id)
-    if user and user.learned_language:
-        user_language = UserLanguage.find_or_create(
-            db_session, user, user.learned_language
-        )
-        user_language.update_streak_if_needed(db_session)
+    if user is None:
+        return
+
+    language = _session_language(session)
+    if language is None:
+        # Exercise / browsing sessions have no content-derived language;
+        # fall back to the user's currently-selected learned_language.
+        language = user.learned_language
+
+    if language is None:
+        return
+
+    user_language = UserLanguage.find_or_create(db_session, user, language)
+    user_language.update_streak_if_needed(db_session)

--- a/zeeguu/api/endpoints/helpers/activity_sessions.py
+++ b/zeeguu/api/endpoints/helpers/activity_sessions.py
@@ -7,7 +7,6 @@ import flask
 from datetime import datetime
 
 from zeeguu.core.model import User
-from zeeguu.core.model.language import Language
 from zeeguu.core.model.user_language import UserLanguage
 
 
@@ -31,58 +30,27 @@ def update_activity_session(session_class, request, db_session):
 
 MIN_STREAK_DURATION_MS = 120_000  # 2 minutes in milliseconds (frontend sends ms)
 
+# Activity sessions belong to a language one of two ways: their content
+# (lesson/article/video) carries it, or — for exercise/browsing sessions
+# which have no content — they snapshot it at session start. The streak
+# must be attributed to *that* language so a tail update arriving after
+# the user toggles their learned_language can't be re-credited elsewhere.
+_CONTENT_RELATIONSHIPS = ("daily_audio_lesson", "article", "video")
+
 
 def _session_language(session):
-    """Return the Language this activity session belongs to, or None.
-
-    The streak must be credited to the language of the *content* the user
-    was practicing when the session began, not to the user's currently-
-    selected `learned_language`. Otherwise, a tail update for a session in
-    language A that arrives after the user has switched to language B
-    incorrectly credits B's streak.
-
-    Listening, reading, and watching sessions carry a content reference
-    (daily audio lesson / article / video) that knows its own language —
-    that's the source of truth for those.
-
-    Exercise and browsing sessions have no content link, but they capture
-    the user's `learned_language_id` at session-creation time on their own
-    `language_id` column (added in 26-04-07 migration). Old rows from
-    before the migration have NULL `language_id`; for those the caller
-    falls back to `user.learned_language`.
-    """
-    daily_audio_lesson = getattr(session, "daily_audio_lesson", None)
-    if daily_audio_lesson is not None:
-        return Language.find_by_id(daily_audio_lesson.language_id)
-
-    article = getattr(session, "article", None)
-    if article is not None:
-        return Language.find_by_id(article.language_id)
-
-    video = getattr(session, "video", None)
-    if video is not None:
-        return Language.find_by_id(video.language_id)
-
-    session_language_id = getattr(session, "language_id", None)
-    if session_language_id is not None:
-        return Language.find_by_id(session_language_id)
-
-    return None
+    for attr in _CONTENT_RELATIONSHIPS:
+        content = getattr(session, attr, None)
+        if content is not None:
+            return content.language
+    # Snapshot column on UserExerciseSession / UserBrowsingSession.
+    # NULL on rows that predate migration 26-04-07.
+    return getattr(session, "language", None)
 
 
 def _update_streak(db_session, session):
     user = User.find_by_id(flask.g.user_id)
-    if user is None:
-        return
-
-    language = _session_language(session)
-    if language is None:
-        # Exercise / browsing sessions have no content-derived language;
-        # fall back to the user's currently-selected learned_language.
-        language = user.learned_language
-
+    language = _session_language(session) or user.learned_language
     if language is None:
         return
-
-    user_language = UserLanguage.find_or_create(db_session, user, language)
-    user_language.update_streak_if_needed(db_session)
+    UserLanguage.find_or_create(db_session, user, language).update_streak_if_needed(db_session)

--- a/zeeguu/api/endpoints/helpers/activity_sessions.py
+++ b/zeeguu/api/endpoints/helpers/activity_sessions.py
@@ -36,14 +36,20 @@ def _session_language(session):
     """Return the Language this activity session belongs to, or None.
 
     The streak must be credited to the language of the *content* the user
-    is practicing, not to the user's currently-selected `learned_language`.
-    Otherwise, a tail update for a session in language A that arrives after
-    the user has switched to language B incorrectly credits B's streak.
+    was practicing when the session began, not to the user's currently-
+    selected `learned_language`. Otherwise, a tail update for a session in
+    language A that arrives after the user has switched to language B
+    incorrectly credits B's streak.
 
-    Listening, reading, and watching sessions all carry a content reference
-    (daily audio lesson / article / video) that knows its own language.
-    Exercise and browsing sessions have no content link, so callers fall
-    back to `user.learned_language` for those.
+    Listening, reading, and watching sessions carry a content reference
+    (daily audio lesson / article / video) that knows its own language —
+    that's the source of truth for those.
+
+    Exercise and browsing sessions have no content link, but they capture
+    the user's `learned_language_id` at session-creation time on their own
+    `language_id` column (added in 26-04-07 migration). Old rows from
+    before the migration have NULL `language_id`; for those the caller
+    falls back to `user.learned_language`.
     """
     daily_audio_lesson = getattr(session, "daily_audio_lesson", None)
     if daily_audio_lesson is not None:
@@ -56,6 +62,10 @@ def _session_language(session):
     video = getattr(session, "video", None)
     if video is not None:
         return Language.find_by_id(video.language_id)
+
+    session_language_id = getattr(session, "language_id", None)
+    if session_language_id is not None:
+        return Language.find_by_id(session_language_id)
 
     return None
 

--- a/zeeguu/api/test/test_browsing_session.py
+++ b/zeeguu/api/test/test_browsing_session.py
@@ -1,14 +1,12 @@
 from fixtures import logged_in_client as client
+from zeeguu.core.model import User, UserBrowsingSession
 
 
 def test_browsing_session_captures_language_at_start(client):
     """Streak attribution must survive a later learned_language toggle, so
     the session captures the user's language at creation time."""
-    from zeeguu.core.model import UserBrowsingSession
-    from zeeguu.core.model.language import Language
-
     session_id = client.post("/browsing_session_start")["id"]
 
     session = UserBrowsingSession.find_by_id(session_id)
-    german = Language.find("de")  # the test fixture creates the user with learned_language="de"
-    assert session.language_id == german.id
+    user = User.find(client.email)
+    assert session.language_id == user.learned_language_id

--- a/zeeguu/api/test/test_browsing_session.py
+++ b/zeeguu/api/test/test_browsing_session.py
@@ -1,0 +1,14 @@
+from fixtures import logged_in_client as client
+
+
+def test_browsing_session_captures_language_at_start(client):
+    """Streak attribution must survive a later learned_language toggle, so
+    the session captures the user's language at creation time."""
+    from zeeguu.core.model import UserBrowsingSession
+    from zeeguu.core.model.language import Language
+
+    session_id = client.post("/browsing_session_start")["id"]
+
+    session = UserBrowsingSession.find_by_id(session_id)
+    german = Language.find("de")  # the test fixture creates the user with learned_language="de"
+    assert session.language_id == german.id

--- a/zeeguu/api/test/test_exercise_session.py
+++ b/zeeguu/api/test/test_exercise_session.py
@@ -7,6 +7,7 @@ from fixtures import (
     add_context_types,
     add_source_types,
 )
+from zeeguu.core.model import User, UserExerciseSession
 from zeeguu.core.test.mocking_the_web import URL_SPIEGEL_VENEZUELA
 
 
@@ -19,14 +20,11 @@ def test_start_new_exercise_session(client):
 def test_exercise_session_captures_language_at_start(client):
     """Streak attribution must survive a later learned_language toggle, so
     the session captures the user's language at creation time."""
-    from zeeguu.core.model import UserExerciseSession
-    from zeeguu.core.model.language import Language
-
     session_id = client.post("/exercise_session_start")["id"]
 
     session = UserExerciseSession.find_by_id(session_id)
-    german = Language.find("de")  # the test fixture creates the user with learned_language="de"
-    assert session.language_id == german.id
+    user = User.find(client.email)
+    assert session.language_id == user.learned_language_id
 
 
 def test_add_exercise_to_session(client):

--- a/zeeguu/api/test/test_exercise_session.py
+++ b/zeeguu/api/test/test_exercise_session.py
@@ -16,6 +16,19 @@ def test_start_new_exercise_session(client):
     assert new_exercise_session["id"]
 
 
+def test_exercise_session_captures_language_at_start(client):
+    """Streak attribution must survive a later learned_language toggle, so
+    the session captures the user's language at creation time."""
+    from zeeguu.core.model import UserExerciseSession
+    from zeeguu.core.model.language import Language
+
+    session_id = client.post("/exercise_session_start")["id"]
+
+    session = UserExerciseSession.find_by_id(session_id)
+    german = Language.find("de")  # the test fixture creates the user with learned_language="de"
+    assert session.language_id == german.id
+
+
 def test_add_exercise_to_session(client):
     add_context_types()
     add_source_types()

--- a/zeeguu/core/model/user_browsing_session.py
+++ b/zeeguu/core/model/user_browsing_session.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from zeeguu.core.model import User
+from zeeguu.core.model.language import Language
 
 from zeeguu.core.util.encoding import datetime_to_json
 from zeeguu.core.util.time import human_readable_duration, human_readable_date
@@ -31,10 +32,16 @@ class UserBrowsingSession(db.Model):
     is_active = db.Column(db.Boolean)
     platform = db.Column(db.SmallInteger)
 
-    def __init__(self, user_id, current_time=None, platform=None):
+    # Captured at session start so streak attribution survives a later
+    # learned_language toggle. See activity_sessions._session_language.
+    language_id = db.Column(db.Integer, db.ForeignKey(Language.id), nullable=True)
+    language = db.relationship(Language)
+
+    def __init__(self, user_id, current_time=None, platform=None, language_id=None):
         self.user_id = user_id
         self.is_active = True
         self.platform = platform
+        self.language_id = language_id
 
         if current_time is None:
             current_time = datetime.now()
@@ -54,7 +61,7 @@ class UserBrowsingSession(db.Model):
         return cls.query.filter(cls.id == session_id).one()
 
     @staticmethod
-    def _create_new_session(db_session, user_id, current_time=None, platform=None):
+    def _create_new_session(db_session, user_id, current_time=None, platform=None, language_id=None):
         """
         Creates a new browsing session
 
@@ -62,11 +69,13 @@ class UserBrowsingSession(db.Model):
         user_id = user identifier
         current_time = optional override for the current time
         platform = platform identifier (see constants.py PLATFORM_*)
+        language_id = the user's learned_language at session start; captured
+            here so streak attribution survives a later language toggle.
         """
         if current_time is None:
             current_time = datetime.now()
 
-        browsing_session = UserBrowsingSession(user_id, current_time, platform)
+        browsing_session = UserBrowsingSession(user_id, current_time, platform, language_id=language_id)
         db_session.add(browsing_session)
         db_session.commit()
         return browsing_session

--- a/zeeguu/core/model/user_browsing_session.py
+++ b/zeeguu/core/model/user_browsing_session.py
@@ -32,8 +32,7 @@ class UserBrowsingSession(db.Model):
     is_active = db.Column(db.Boolean)
     platform = db.Column(db.SmallInteger)
 
-    # Captured at session start so streak attribution survives a later
-    # learned_language toggle. See activity_sessions._session_language.
+    # Snapshot of user.learned_language_id at session start; see activity_sessions._session_language.
     language_id = db.Column(db.Integer, db.ForeignKey(Language.id), nullable=True)
     language = db.relationship(Language)
 
@@ -69,8 +68,7 @@ class UserBrowsingSession(db.Model):
         user_id = user identifier
         current_time = optional override for the current time
         platform = platform identifier (see constants.py PLATFORM_*)
-        language_id = the user's learned_language at session start; captured
-            here so streak attribution survives a later language toggle.
+        language_id = snapshot of user.learned_language_id; see activity_sessions._session_language
         """
         if current_time is None:
             current_time = datetime.now()

--- a/zeeguu/core/model/user_exercise_session.py
+++ b/zeeguu/core/model/user_exercise_session.py
@@ -3,6 +3,7 @@ import zeeguu.core
 
 from datetime import datetime, timedelta
 from zeeguu.core.model.user import User
+from zeeguu.core.model.language import Language
 
 from zeeguu.core.model.db import db
 
@@ -32,10 +33,16 @@ class UserExerciseSession(db.Model):
     is_active = db.Column(db.Boolean)
     platform = db.Column(db.SmallInteger)
 
-    def __init__(self, user_id, start_time, current_time=None, platform=None):
+    # Captured at session start so streak attribution survives a later
+    # learned_language toggle. See activity_sessions._session_language.
+    language_id = db.Column(db.Integer, db.ForeignKey(Language.id), nullable=True)
+    language = db.relationship(Language)
+
+    def __init__(self, user_id, start_time, current_time=None, platform=None, language_id=None):
         self.user_id = user_id
         self.is_active = False
         self.platform = platform
+        self.language_id = language_id
 
         # When we want to emulate an event happening in a particular moment in the past or in the future,
         #   we can provide the current_time variable to override the datetime.now()

--- a/zeeguu/core/model/user_exercise_session.py
+++ b/zeeguu/core/model/user_exercise_session.py
@@ -33,8 +33,7 @@ class UserExerciseSession(db.Model):
     is_active = db.Column(db.Boolean)
     platform = db.Column(db.SmallInteger)
 
-    # Captured at session start so streak attribution survives a later
-    # learned_language toggle. See activity_sessions._session_language.
+    # Snapshot of user.learned_language_id at session start; see activity_sessions._session_language.
     language_id = db.Column(db.Integer, db.ForeignKey(Language.id), nullable=True)
     language = db.relationship(Language)
 


### PR DESCRIPTION
## Summary

Fixes a bug where, after listening to ~3 minutes of an audio lesson in language A and then toggling the UI to language B, the streak (with chime + animation) was instantly attributed to **language B**.

### Root cause

`update_activity_session` calls `_update_streak`, which always read `user.learned_language` *at request time* to decide whose streak to bump:

```python
def _update_streak(db_session):
    user = User.find_by_id(flask.g.user_id)
    if user and user.learned_language:
        user_language = UserLanguage.find_or_create(
            db_session, user, user.learned_language
        )
        user_language.update_streak_if_needed(db_session)
```

So any tail update for an in-flight session — the next 10s tick of the frontend `useListeningSession` interval, a `listening_session_end` flushed via beacon, etc. — that arrives after the user toggled language gets credited to the *new* language. This affects every endpoint that funnels through `update_activity_session`: listening, reading, watching, exercise, and browsing sessions.

### Fix

Two commits:

**1. Credit streak to session language for content-bearing sessions** (`ce6941c0`)

`UserListeningSession`, `UserReadingSession`, and `UserWatchingSession` all carry a content reference (`daily_audio_lesson` / `article` / `video`) that knows its own `language_id`. A small `_session_language(session)` helper derives the streak language from the session's content.

**2. Capture language at exercise/browsing session start** (`cd758534`)

Exercise and browsing sessions have no content link, so they had a milder version of the same race. Fixed by adding a `language_id` column to both tables and capturing the user's `learned_language_id` at session-creation time. The helper now reads it directly. Old rows from before the migration have NULL `language_id`; for those, the helper still falls back to `user.learned_language`.

Migration: `tools/migrations/26-04-07--add_language_id_to_exercise_and_browsing_sessions.sql`

### Notes

- There's a complementary frontend fix (zeeguu/web#1023) that ends the listening session on language toggle so the tail update stops firing in the first place. Both fixes are independently useful: the backend protects against any late update; the frontend avoids the unnecessary work.

## Test plan

- [x] `python -m pytest zeeguu/api/test/test_exercise_session.py zeeguu/api/test/test_browsing_session.py zeeguu/api/test/test_reading_session.py` — 7 passed
- [x] New tests assert `language_id` is captured at exercise + browsing session start
- [ ] Apply migration to staging/prod before deploy: `26-04-07--add_language_id_to_exercise_and_browsing_sessions.sql`
- [ ] Manual: listen to ~3 min of audio in DE, toggle to FR, confirm FR streak is **not** bumped
- [ ] Manual: listen to ~3 min in DE without switching, confirm DE streak still bumps as before
- [ ] Manual: do ~3 min of exercises in DE, toggle to FR, confirm FR streak is **not** bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)