### PR TITLE
Add watching_session_end endpoint

### DIFF
--- a/zeeguu/api/endpoints/user_watching_session.py
+++ b/zeeguu/api/endpoints/user_watching_session.py
@@ -34,3 +34,18 @@ def watching_session_start():
 def watching_session_update():
     session = update_activity_session(UserWatchingSession, request, db_session)
     return json_result(dict(id=session.id, duration=session.duration))
+
+
+# ---------------------------------------------------------------------------
+@api.route("/watching_session_end", methods=["POST"])
+# ---------------------------------------------------------------------------
+# UserWatchingSession has no is_active flag (unlike listening/reading/etc),
+# so this endpoint is functionally a final-update. It exists for symmetry
+# with the other session types and to give the frontend a clear "this is
+# the end" semantic that can grow side effects later without a frontend
+# change.
+@cross_domain
+@requires_session
+def watching_session_end():
+    session = update_activity_session(UserWatchingSession, request, db_session)
+    return json_result(dict(id=session.id, duration=session.duration))


### PR DESCRIPTION
Companion to zeeguu/web#1023, which introduces a `useWatchingSession` hook that calls `api.endWatchingSession` on cleanup.

## Summary

Adds a new `/watching_session_end` endpoint that mirrors `watching_session_update`. Today the body is functionally identical (`UserWatchingSession` has no `is_active` flag, unlike listening/reading/exercise/browsing), so this is a +15-line addition with no schema change.

The endpoint exists for symmetry with other session types and to give the frontend a clear "this is the final flush" semantic. We can grow side effects on it later (analytics, optional `is_active` if the model gains that column) without touching the frontend.

The streak credit still flows correctly via `update_activity_session`, which routes through the session-language attribution from #525.

## Test plan

- [x] Module imports cleanly
- [ ] Manual: open a video, watch for 3+ min, navigate away — confirm a final beacon hits `/watching_session_end` (200)
- [ ] Manual: confirm watching streak still bumps after 2+ min of watching, with the correct language attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)