### PR TITLE
Compute daily streaks in user's local timezone

### DIFF
--- a/tools/migrations/26-04-11--add_user_timezone.sql
+++ b/tools/migrations/26-04-11--add_user_timezone.sql
@@ -1,0 +1,5 @@
+-- Store the user's IANA timezone (e.g. "Europe/Copenhagen") so streak math
+-- can be done in the user's local day instead of the server's day.
+-- NULL means "fall back to server time" — the client populates this on next launch.
+ALTER TABLE user
+ADD COLUMN timezone VARCHAR(64) NULL;

--- a/zeeguu/api/endpoints/daily_streak.py
+++ b/zeeguu/api/endpoints/daily_streak.py
@@ -3,7 +3,7 @@ import flask
 
 from zeeguu.api.utils.json_result import json_result
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
-from zeeguu.core.util.time import user_today, to_user_local_date, user_zone
+from zeeguu.core.util.time import user_local_today, to_user_local_date, user_zone
 from . import api
 from ...core.model import User
 from ...core.model.user_language import UserLanguage
@@ -17,7 +17,7 @@ def get_daily_streak():
     user = User.find_by_id(flask.g.user_id)
     user_language = UserLanguage.find_or_create(db.session, user, user.learned_language)
     streak = user_language.daily_streak or 0
-    yesterday = user_today(user) - datetime.timedelta(days=1)
+    yesterday = user_local_today(user) - datetime.timedelta(days=1)
     last_local = to_user_local_date(user, user_language.last_practiced)
     if last_local and last_local < yesterday:
         streak = 0
@@ -31,7 +31,7 @@ def get_all_language_streaks():
     user = User.find_by_id(flask.g.user_id)
     user_languages = UserLanguage.query.filter_by(user_id=user.id).all()
     zone = user_zone(user)
-    today = user_today(user, zone=zone)
+    today = user_local_today(user, zone=zone)
     yesterday = today - datetime.timedelta(days=1)
     result = []
     for ul in user_languages:

--- a/zeeguu/api/endpoints/daily_streak.py
+++ b/zeeguu/api/endpoints/daily_streak.py
@@ -18,7 +18,7 @@ def get_daily_streak():
     user_language = UserLanguage.find_or_create(db.session, user, user.learned_language)
     streak = user_language.daily_streak or 0
     yesterday = user_local_today(user) - datetime.timedelta(days=1)
-    last_local = user_language.last_practiced_local
+    last_local = user_language.local_last_practiced
     if last_local and last_local < yesterday:
         streak = 0
     return json_result({"daily_streak": streak})
@@ -36,7 +36,7 @@ def get_all_language_streaks():
     for ul in user_languages:
         if ul.language_id == user.native_language_id:
             continue
-        last_local = ul.last_practiced_local
+        last_local = ul.local_last_practiced
         practiced_today = last_local == today
         # Streak is only valid if practiced today or yesterday
         streak = ul.daily_streak or 0

--- a/zeeguu/api/endpoints/daily_streak.py
+++ b/zeeguu/api/endpoints/daily_streak.py
@@ -31,7 +31,7 @@ def get_all_language_streaks():
     user = User.find_by_id(flask.g.user_id)
     user_languages = UserLanguage.query.filter_by(user_id=user.id).all()
     zone = user_zone(user)
-    today = datetime.datetime.now(zone).date()
+    today = user_today(user, zone=zone)
     yesterday = today - datetime.timedelta(days=1)
     result = []
     for ul in user_languages:

--- a/zeeguu/api/endpoints/daily_streak.py
+++ b/zeeguu/api/endpoints/daily_streak.py
@@ -3,7 +3,7 @@ import flask
 
 from zeeguu.api.utils.json_result import json_result
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
-from zeeguu.core.util.time import user_today, to_user_local_date
+from zeeguu.core.util.time import user_today, to_user_local_date, user_zone
 from . import api
 from ...core.model import User
 from ...core.model.user_language import UserLanguage
@@ -30,13 +30,14 @@ def get_daily_streak():
 def get_all_language_streaks():
     user = User.find_by_id(flask.g.user_id)
     user_languages = UserLanguage.query.filter_by(user_id=user.id).all()
-    today = user_today(user)
+    zone = user_zone(user)
+    today = datetime.datetime.now(zone).date()
     yesterday = today - datetime.timedelta(days=1)
     result = []
     for ul in user_languages:
         if ul.language_id == user.native_language_id:
             continue
-        last_local = to_user_local_date(user, ul.last_practiced)
+        last_local = to_user_local_date(user, ul.last_practiced, zone=zone)
         practiced_today = last_local == today
         # Streak is only valid if practiced today or yesterday
         streak = ul.daily_streak or 0

--- a/zeeguu/api/endpoints/daily_streak.py
+++ b/zeeguu/api/endpoints/daily_streak.py
@@ -3,7 +3,7 @@ import flask
 
 from zeeguu.api.utils.json_result import json_result
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
-from zeeguu.core.util.time import user_local_today, to_user_local_date, user_zone
+from zeeguu.core.util.time import user_local_today
 from . import api
 from ...core.model import User
 from ...core.model.user_language import UserLanguage
@@ -18,7 +18,7 @@ def get_daily_streak():
     user_language = UserLanguage.find_or_create(db.session, user, user.learned_language)
     streak = user_language.daily_streak or 0
     yesterday = user_local_today(user) - datetime.timedelta(days=1)
-    last_local = to_user_local_date(user, user_language.last_practiced)
+    last_local = user_language.last_practiced_local
     if last_local and last_local < yesterday:
         streak = 0
     return json_result({"daily_streak": streak})
@@ -30,14 +30,13 @@ def get_daily_streak():
 def get_all_language_streaks():
     user = User.find_by_id(flask.g.user_id)
     user_languages = UserLanguage.query.filter_by(user_id=user.id).all()
-    zone = user_zone(user)
-    today = user_local_today(user, zone=zone)
+    today = user_local_today(user)
     yesterday = today - datetime.timedelta(days=1)
     result = []
     for ul in user_languages:
         if ul.language_id == user.native_language_id:
             continue
-        last_local = to_user_local_date(user, ul.last_practiced, zone=zone)
+        last_local = ul.last_practiced_local
         practiced_today = last_local == today
         # Streak is only valid if practiced today or yesterday
         streak = ul.daily_streak or 0

--- a/zeeguu/api/endpoints/daily_streak.py
+++ b/zeeguu/api/endpoints/daily_streak.py
@@ -1,4 +1,3 @@
-import datetime
 import flask
 
 from zeeguu.api.utils.json_result import json_result
@@ -15,13 +14,8 @@ from ...core.model.db import db
 @requires_session
 def get_daily_streak():
     user = User.find_by_id(flask.g.user_id)
-    user_language = UserLanguage.find_or_create(db.session, user, user.learned_language)
-    streak = user_language.daily_streak or 0
-    yesterday = user_local_today(user) - datetime.timedelta(days=1)
-    last_local = user_language.local_last_practiced
-    if last_local and last_local < yesterday:
-        streak = 0
-    return json_result({"daily_streak": streak})
+    ul = UserLanguage.find_or_create(db.session, user, user.learned_language)
+    return json_result({"daily_streak": ul.current_daily_streak})
 
 
 @api.route("/all_language_streaks", methods=["GET"])
@@ -29,25 +23,16 @@ def get_daily_streak():
 @requires_session
 def get_all_language_streaks():
     user = User.find_by_id(flask.g.user_id)
-    user_languages = UserLanguage.query.filter_by(user_id=user.id).all()
     today = user_local_today(user)
-    yesterday = today - datetime.timedelta(days=1)
-    result = []
-    for ul in user_languages:
-        if ul.language_id == user.native_language_id:
-            continue
-        last_local = ul.local_last_practiced
-        practiced_today = last_local == today
-        # Streak is only valid if practiced today or yesterday
-        streak = ul.daily_streak or 0
-        if last_local and last_local < yesterday:
-            streak = 0
-        result.append({
+    result = [
+        {
             "code": ul.language.code,
             "language": ul.language.name,
-            "daily_streak": streak,
-            "practiced_today": practiced_today,
-        })
-    # Sort by streak descending so highest streaks come first
+            "daily_streak": ul.current_daily_streak,
+            "practiced_today": ul.local_last_practiced == today,
+        }
+        for ul in UserLanguage.query.filter_by(user_id=user.id).all()
+        if ul.language_id != user.native_language_id
+    ]
     result.sort(key=lambda x: x["daily_streak"], reverse=True)
     return json_result(result)

--- a/zeeguu/api/endpoints/daily_streak.py
+++ b/zeeguu/api/endpoints/daily_streak.py
@@ -3,6 +3,7 @@ import flask
 
 from zeeguu.api.utils.json_result import json_result
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
+from zeeguu.core.util.time import user_today, to_user_local_date
 from . import api
 from ...core.model import User
 from ...core.model.user_language import UserLanguage
@@ -16,8 +17,9 @@ def get_daily_streak():
     user = User.find_by_id(flask.g.user_id)
     user_language = UserLanguage.find_or_create(db.session, user, user.learned_language)
     streak = user_language.daily_streak or 0
-    yesterday = datetime.date.today() - datetime.timedelta(days=1)
-    if user_language.last_practiced and user_language.last_practiced.date() < yesterday:
+    yesterday = user_today(user) - datetime.timedelta(days=1)
+    last_local = to_user_local_date(user, user_language.last_practiced)
+    if last_local and last_local < yesterday:
         streak = 0
     return json_result({"daily_streak": streak})
 
@@ -28,19 +30,17 @@ def get_daily_streak():
 def get_all_language_streaks():
     user = User.find_by_id(flask.g.user_id)
     user_languages = UserLanguage.query.filter_by(user_id=user.id).all()
+    today = user_today(user)
+    yesterday = today - datetime.timedelta(days=1)
     result = []
     for ul in user_languages:
         if ul.language_id == user.native_language_id:
             continue
-        today = datetime.date.today()
-        yesterday = today - datetime.timedelta(days=1)
-        practiced_today = (
-            ul.last_practiced is not None
-            and ul.last_practiced.date() == today
-        )
+        last_local = to_user_local_date(user, ul.last_practiced)
+        practiced_today = last_local == today
         # Streak is only valid if practiced today or yesterday
         streak = ul.daily_streak or 0
-        if ul.last_practiced and ul.last_practiced.date() < yesterday:
+        if last_local and last_local < yesterday:
             streak = 0
         result.append({
             "code": ul.language.code,

--- a/zeeguu/api/endpoints/user.py
+++ b/zeeguu/api/endpoints/user.py
@@ -1,4 +1,5 @@
 import flask
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import zeeguu.core
 from zeeguu.api.endpoints.feature_toggles import features_for_user
@@ -94,13 +95,6 @@ def learned_and_native_language():
 @cross_domain
 @requires_session
 def set_user_timezone():
-    """
-    Persist the client's IANA timezone (e.g. "Europe/Copenhagen") so daily
-    streaks roll over at the user's local midnight instead of the server's.
-    The client posts this on launch and on resume whenever the value changes.
-    """
-    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-
     tz = flask.request.form.get("timezone", "").strip()
     try:
         ZoneInfo(tz)

--- a/zeeguu/api/endpoints/user.py
+++ b/zeeguu/api/endpoints/user.py
@@ -90,6 +90,29 @@ def learned_and_native_language():
     return json_result(res)
 
 
+@api.route("/user_timezone", methods=["POST"])
+@cross_domain
+@requires_session
+def set_user_timezone():
+    """
+    Persist the client's IANA timezone (e.g. "Europe/Copenhagen") so daily
+    streaks roll over at the user's local midnight instead of the server's.
+    The client posts this on launch and on resume whenever the value changes.
+    """
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+    tz = flask.request.form.get("timezone", "").strip()
+    try:
+        ZoneInfo(tz)
+    except (ZoneInfoNotFoundError, ValueError):
+        flask.abort(400, "invalid timezone")
+
+    user = User.find_by_id(flask.g.user_id)
+    user.timezone = tz
+    zeeguu.core.model.db.session.commit()
+    return "OK"
+
+
 @api.route("/get_unfinished_user_reading_sessions", methods=("GET",))
 @api.route(
     "/get_unfinished_user_reading_sessions/<int:total_sessions>", methods=("GET",)

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -61,6 +61,7 @@ class User(db.Model):
     last_seen = db.Column(db.DateTime, nullable=True)
     creation_platform = db.Column(db.SmallInteger, nullable=True)
     daily_streak = db.Column(db.Integer, default=0)
+    timezone = db.Column(db.String(64), nullable=True)
 
     def __init__(
         self,

--- a/zeeguu/core/model/user_language.py
+++ b/zeeguu/core/model/user_language.py
@@ -50,6 +50,10 @@ class UserLanguage(db.Model):
     last_practiced = Column(DateTime, nullable=True)
     daily_streak = Column(Integer, default=0)
 
+    @property
+    def last_practiced_local(self):
+        return to_user_local_date(self.user, self.last_practiced)
+
     def __init__(
         self,
         user,
@@ -127,7 +131,7 @@ class UserLanguage(db.Model):
         Only updates once per day to minimize database writes.
         """
         today = user_local_today(self.user)
-        last_local = to_user_local_date(self.user, self.last_practiced)
+        last_local = self.last_practiced_local
 
         if last_local is None or last_local < today:
             if last_local is None:

--- a/zeeguu/core/model/user_language.py
+++ b/zeeguu/core/model/user_language.py
@@ -125,16 +125,19 @@ class UserLanguage(db.Model):
         Update last_practiced timestamp and daily_streak counter for this language.
         Only updates once per day to minimize database writes.
         """
-        now = datetime.datetime.now()
+        from zeeguu.core.util.time import user_today, to_user_local_date
 
-        if not self.last_practiced or self.last_practiced.date() < now.date():
-            if not self.last_practiced:
+        today = user_today(self.user)
+        last_local = to_user_local_date(self.user, self.last_practiced)
+
+        if last_local is None or last_local < today:
+            if last_local is None:
                 self.daily_streak = 1
-            elif self.last_practiced.date() == now.date() - datetime.timedelta(days=1):
+            elif last_local == today - datetime.timedelta(days=1):
                 self.daily_streak = (self.daily_streak or 0) + 1
             else:
                 self.daily_streak = 1
 
-            self.last_practiced = now
+            self.last_practiced = datetime.datetime.now()
             if session:
                 session.add(self)

--- a/zeeguu/core/model/user_language.py
+++ b/zeeguu/core/model/user_language.py
@@ -6,6 +6,7 @@ from sqlalchemy import Column, Integer, ForeignKey, Boolean, DateTime
 from sqlalchemy.orm import relationship
 
 from zeeguu.core.model import User
+from zeeguu.core.util.time import user_today, to_user_local_date
 
 import zeeguu.core
 
@@ -125,8 +126,6 @@ class UserLanguage(db.Model):
         Update last_practiced timestamp and daily_streak counter for this language.
         Only updates once per day to minimize database writes.
         """
-        from zeeguu.core.util.time import user_today, to_user_local_date
-
         today = user_today(self.user)
         last_local = to_user_local_date(self.user, self.last_practiced)
 

--- a/zeeguu/core/model/user_language.py
+++ b/zeeguu/core/model/user_language.py
@@ -6,7 +6,7 @@ from sqlalchemy import Column, Integer, ForeignKey, Boolean, DateTime
 from sqlalchemy.orm import relationship
 
 from zeeguu.core.model import User
-from zeeguu.core.util.time import user_today, to_user_local_date
+from zeeguu.core.util.time import user_local_today, to_user_local_date
 
 import zeeguu.core
 
@@ -126,7 +126,7 @@ class UserLanguage(db.Model):
         Update last_practiced timestamp and daily_streak counter for this language.
         Only updates once per day to minimize database writes.
         """
-        today = user_today(self.user)
+        today = user_local_today(self.user)
         last_local = to_user_local_date(self.user, self.last_practiced)
 
         if last_local is None or last_local < today:

--- a/zeeguu/core/model/user_language.py
+++ b/zeeguu/core/model/user_language.py
@@ -54,6 +54,16 @@ class UserLanguage(db.Model):
     def local_last_practiced(self):
         return to_user_local_date(self.user, self.last_practiced)
 
+    @property
+    def current_daily_streak(self):
+        """Stored streak, zeroed out if not practiced today or yesterday."""
+        last = self.local_last_practiced
+        if last is None:
+            return 0
+        if last < user_local_today(self.user) - datetime.timedelta(days=1):
+            return 0
+        return self.daily_streak or 0
+
     def __init__(
         self,
         user,

--- a/zeeguu/core/model/user_language.py
+++ b/zeeguu/core/model/user_language.py
@@ -51,7 +51,7 @@ class UserLanguage(db.Model):
     daily_streak = Column(Integer, default=0)
 
     @property
-    def last_practiced_local(self):
+    def local_last_practiced(self):
         return to_user_local_date(self.user, self.last_practiced)
 
     def __init__(
@@ -131,7 +131,7 @@ class UserLanguage(db.Model):
         Only updates once per day to minimize database writes.
         """
         today = user_local_today(self.user)
-        last_local = self.last_practiced_local
+        last_local = self.local_last_practiced
 
         if last_local is None or last_local < today:
             if last_local is None:

--- a/zeeguu/core/model/user_language.py
+++ b/zeeguu/core/model/user_language.py
@@ -57,11 +57,15 @@ class UserLanguage(db.Model):
     @property
     def current_daily_streak(self):
         """Stored streak, zeroed out if not practiced today or yesterday."""
-        last = self.local_last_practiced
-        if last is None:
+        last_practiced = self.local_last_practiced
+        yesterday = user_local_today(self.user) - datetime.timedelta(days=1)
+
+        if last_practiced is None:
             return 0
-        if last < user_local_today(self.user) - datetime.timedelta(days=1):
+
+        if last_practiced < yesterday:
             return 0
+
         return self.daily_streak or 0
 
     def __init__(

--- a/zeeguu/core/util/time.py
+++ b/zeeguu/core/util/time.py
@@ -19,15 +19,14 @@ def user_zone(user):
     return SERVER_TZ
 
 
-def user_today(user):
-    return datetime.now(user_zone(user)).date()
+def user_today(user, zone=None):
+    return datetime.now(zone or user_zone(user)).date()
 
 
 def to_user_local_date(user, naive_server_dt, zone=None):
     if naive_server_dt is None:
         return None
-    target = zone or user_zone(user)
-    return naive_server_dt.replace(tzinfo=SERVER_TZ).astimezone(target).date()
+    return naive_server_dt.replace(tzinfo=SERVER_TZ).astimezone(zone or user_zone(user)).date()
 
 """
 datetime (dt) is not by default a timezone aware object. When articles

--- a/zeeguu/core/util/time.py
+++ b/zeeguu/core/util/time.py
@@ -4,15 +4,14 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 SERVER_HOUR_DIFFERENCE = 1  # Frankfurt is +1 from UTC
 
-# Naive DB datetimes (e.g. user_language.last_practiced) are stored in
-# server-local time — see normalize_to_server_time below. SERVER_TZ tags
-# them with the running process's local zone so we can convert to a user's
-# local zone for streak comparisons.
-SERVER_TZ = datetime.now().astimezone().tzinfo
+# Pinned to Frankfurt to match the project's existing convention (see
+# normalize_to_server_time). IANA so DST is handled — a naive offset
+# would silently mis-bucket streaks twice a year.
+SERVER_TZ = ZoneInfo("Europe/Berlin")
 
 
-def _user_zone(user):
-    if user is not None and getattr(user, "timezone", None):
+def user_zone(user):
+    if getattr(user, "timezone", None):
         try:
             return ZoneInfo(user.timezone)
         except ZoneInfoNotFoundError:
@@ -21,19 +20,14 @@ def _user_zone(user):
 
 
 def user_today(user):
-    """Today's calendar date in the user's local timezone."""
-    return datetime.now(_user_zone(user)).date()
+    return datetime.now(user_zone(user)).date()
 
 
-def to_user_local_date(user, naive_server_dt):
-    """Reinterpret a naive server-local datetime as the user's local date."""
+def to_user_local_date(user, naive_server_dt, zone=None):
     if naive_server_dt is None:
         return None
-    return (
-        naive_server_dt.replace(tzinfo=SERVER_TZ)
-        .astimezone(_user_zone(user))
-        .date()
-    )
+    target = zone or user_zone(user)
+    return naive_server_dt.replace(tzinfo=SERVER_TZ).astimezone(target).date()
 
 """
 datetime (dt) is not by default a timezone aware object. When articles

--- a/zeeguu/core/util/time.py
+++ b/zeeguu/core/util/time.py
@@ -19,7 +19,7 @@ def user_zone(user):
     return SERVER_TZ
 
 
-def user_today(user, zone=None):
+def user_local_today(user, zone=None):
     return datetime.now(zone or user_zone(user)).date()
 
 

--- a/zeeguu/core/util/time.py
+++ b/zeeguu/core/util/time.py
@@ -19,14 +19,14 @@ def user_zone(user):
     return SERVER_TZ
 
 
-def user_local_today(user, zone=None):
-    return datetime.now(zone or user_zone(user)).date()
+def user_local_today(user):
+    return datetime.now(user_zone(user)).date()
 
 
-def to_user_local_date(user, naive_server_dt, zone=None):
+def to_user_local_date(user, naive_server_dt):
     if naive_server_dt is None:
         return None
-    return naive_server_dt.replace(tzinfo=SERVER_TZ).astimezone(zone or user_zone(user)).date()
+    return naive_server_dt.replace(tzinfo=SERVER_TZ).astimezone(user_zone(user)).date()
 
 """
 datetime (dt) is not by default a timezone aware object. When articles

--- a/zeeguu/core/util/time.py
+++ b/zeeguu/core/util/time.py
@@ -1,7 +1,39 @@
 from datetime import datetime, timezone, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
 SERVER_HOUR_DIFFERENCE = 1  # Frankfurt is +1 from UTC
+
+# Naive DB datetimes (e.g. user_language.last_practiced) are stored in
+# server-local time — see normalize_to_server_time below. SERVER_TZ tags
+# them with the running process's local zone so we can convert to a user's
+# local zone for streak comparisons.
+SERVER_TZ = datetime.now().astimezone().tzinfo
+
+
+def _user_zone(user):
+    if user is not None and getattr(user, "timezone", None):
+        try:
+            return ZoneInfo(user.timezone)
+        except ZoneInfoNotFoundError:
+            pass
+    return SERVER_TZ
+
+
+def user_today(user):
+    """Today's calendar date in the user's local timezone."""
+    return datetime.now(_user_zone(user)).date()
+
+
+def to_user_local_date(user, naive_server_dt):
+    """Reinterpret a naive server-local datetime as the user's local date."""
+    if naive_server_dt is None:
+        return None
+    return (
+        naive_server_dt.replace(tzinfo=SERVER_TZ)
+        .astimezone(_user_zone(user))
+        .date()
+    )
 
 """
 datetime (dt) is not by default a timezone aware object. When articles


### PR DESCRIPTION
## Summary
- Streaks were rolling over at server midnight, breaking the rollover for users far from the server's zone (e.g. practicing at 11pm local got recorded as the next day, looking like a 2-day gap).
- New `user.timezone` column stores the client-reported IANA zone (e.g. `Europe/Copenhagen`). NULL falls back to server time, so rollout is zero-downtime — clients populate it on next launch.
- Both read endpoints (`/daily_streak`, `/all_language_streaks`) and the write-side `UserLanguage.update_streak_if_needed` now compare dates in the user's local zone via two new helpers in `core/util/time.py` (`user_today`, `to_user_local_date`).
- New `POST /user_timezone` endpoint validates the value via `zoneinfo.ZoneInfo()` and persists it.

## Notes
- Naive DB datetimes remain in server-local time per the project's documented convention; conversion happens only at comparison time.
- Pairs with web PR: zeeguu/web#user-timezone-streaks.

## Test plan
- [ ] Run migration `tools/migrations/26-04-11--add_user_timezone.sql` on staging
- [ ] `POST /user_timezone` with `timezone=Europe/Copenhagen` returns OK; with garbage returns 400
- [ ] Set a test user's timezone to `Pacific/Auckland`, practice at 11pm server time, confirm streak counts as "today" in NZ
- [ ] Existing user with `timezone=NULL` sees unchanged streak behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)