### PR TITLE
Introduce ArticleUpload for extension/share ingestion

### DIFF
--- a/tools/migrations/26-04-14--add_article_upload.sql
+++ b/tools/migrations/26-04-14--add_article_upload.sql
@@ -1,0 +1,31 @@
+-- Per-user lightweight ingestion entity for articles sent from the extension
+-- (and later iOS share). Holds the raw HTML client-side scrape so we can
+-- derive simplified/adapted/promoted Article rows on user choice, without
+-- paying full ingestion cost (Stanza, CEFR LLM, fragments, topics) up front.
+-- See docs/future-work/extension-ingestion-unification.md
+
+CREATE TABLE article_upload (
+    id INT NOT NULL AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    url_id INT NOT NULL,
+    language_id INT NOT NULL,
+    title VARCHAR(512) DEFAULT NULL,
+    raw_html MEDIUMTEXT,
+    text_content MEDIUMTEXT,
+    image_url VARCHAR(2048) DEFAULT NULL,
+    author VARCHAR(256) DEFAULT NULL,
+    created_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    KEY ix_article_upload_user_id (user_id),
+    KEY ix_article_upload_url_id (url_id),
+    CONSTRAINT fk_article_upload_user FOREIGN KEY (user_id) REFERENCES user (id),
+    CONSTRAINT fk_article_upload_url FOREIGN KEY (url_id) REFERENCES url (id),
+    CONSTRAINT fk_article_upload_language FOREIGN KEY (language_id) REFERENCES language (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+
+-- Back-reference from Article to the upload it was derived from.
+-- Nullable: normal feed / teacher-uploaded articles don't have one.
+ALTER TABLE article
+    ADD COLUMN source_upload_id INT DEFAULT NULL,
+    ADD CONSTRAINT fk_article_source_upload
+        FOREIGN KEY (source_upload_id) REFERENCES article_upload (id);

--- a/zeeguu/api/endpoints/__init__.py
+++ b/zeeguu/api/endpoints/__init__.py
@@ -28,6 +28,7 @@ from .teacher_dashboard import *
 from . import topics
 from . import search
 from . import article
+from . import article_upload
 from . import accounts
 from . import speech
 from . import own_texts

--- a/zeeguu/api/endpoints/article_upload.py
+++ b/zeeguu/api/endpoints/article_upload.py
@@ -1,18 +1,7 @@
-"""
-Endpoints for ArticleUpload — the lightweight per-user ingestion entity.
-
-The Chrome extension scrapes the page body, POSTs it here to create an
-ArticleUpload, then navigates to /shared-article?upload_id=<id>. The
-SharedArticleHandler fetches upload info and shows the choice modal.
-On the user's choice, one of the derivation endpoints below runs:
-the upload's content becomes a full Article (promoted / simplified /
-translated-and-adapted), PersonalCopy is created, and the client
-navigates to the reader.
-
-See docs/future-work/extension-ingestion-unification.md
-"""
+"""Endpoints for ArticleUpload — lightweight per-user ingestion entity."""
 import flask
 from flask import request
+from sqlalchemy.orm.exc import NoResultFound
 
 from zeeguu.core.model import Article, ArticleUpload, User
 from zeeguu.core.model.personal_copy import PersonalCopy
@@ -21,6 +10,8 @@ from zeeguu.api.utils.json_result import json_result
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
 
 from . import api, db_session
+
+_DEFAULT_CEFR_LEVEL = "A2"
 
 
 def _find_upload_or_404(upload_id, user):
@@ -32,22 +23,33 @@ def _find_upload_or_404(upload_id, user):
     return upload
 
 
-def _promote_upload(upload):
-    """
-    Promote an upload's raw content into a full Article row, setting
-    source_upload_id as the back-reference. Reuses Article.find_or_create
-    so all existing work (fragments, FK, topics, CEFR) happens exactly once.
-    """
-    return Article.find_or_create(
-        db_session,
-        upload.url.as_string(),
-        html_content=upload.raw_html,
-        text_content=upload.text_content,
-        title=upload.title,
-        author=upload.author,
-        image_url=upload.image_url,
-        source_upload_id=upload.id,
+def _promote_upload_or_abort(upload):
+    from zeeguu.core.content_retriever.crawler_exceptions import (
+        FailedToParseWithReadabilityServer,
     )
+
+    try:
+        return Article.find_or_create(
+            db_session,
+            upload.url.as_string(),
+            html_content=upload.raw_html,
+            text_content=upload.text_content,
+            title=upload.title,
+            author=upload.author,
+            image_url=upload.image_url,
+            source_upload_id=upload.id,
+        )
+    except NoResultFound:
+        flask.abort(406, "Language not supported")
+    except FailedToParseWithReadabilityServer:
+        flask.abort(422, "Could not parse article content")
+
+
+def _user_cefr_level(user):
+    try:
+        return user.cefr_level_for_learned_language()
+    except Exception:
+        return _DEFAULT_CEFR_LEVEL
 
 
 def _ensure_personal_copy(user, article):
@@ -59,17 +61,6 @@ def _ensure_personal_copy(user, article):
 @cross_domain
 @requires_session
 def article_upload_create():
-    """
-    Create a new ArticleUpload from client-scraped content.
-
-    Expects (form):
-      - url (required)
-      - raw_html (optional but typical for extension)
-      - text_content (optional; extension usually sends this too)
-      - title, image_url, author (optional)
-
-    Returns: { upload_id, url, title, language, image_url, author, created_at }
-    """
     url = request.form.get("url", "").strip()
     if not url:
         flask.abort(400, "url required")
@@ -102,7 +93,6 @@ def article_upload_create():
 @cross_domain
 @requires_session
 def article_upload_get(upload_id):
-    """Return upload info for the SharedArticleHandler choice modal."""
     user = User.find_by_id(flask.g.user_id)
     upload = _find_upload_or_404(upload_id, user)
     return json_result(upload.as_dictionary())
@@ -112,15 +102,10 @@ def article_upload_get(upload_id):
 @cross_domain
 @requires_session
 def article_upload_promote(upload_id):
-    """
-    Read Original / Read As-Is: promote the upload to a full Article and
-    add a PersonalCopy for the user. Returns user_article_info so the
-    client can navigate directly to the reader.
-    """
     user = User.find_by_id(flask.g.user_id)
     upload = _find_upload_or_404(upload_id, user)
 
-    article = _promote_upload(upload)
+    article = _promote_upload_or_abort(upload)
     if not article.cefr_assessment or not article.cefr_assessment.llm_cefr_level:
         article.assess_cefr_level(db_session)
 
@@ -133,11 +118,6 @@ def article_upload_promote(upload_id):
 @cross_domain
 @requires_session
 def article_upload_simplify(upload_id):
-    """
-    Promote the upload (so simplification has a parent Article to anchor to)
-    and create a simplified version at the user's CEFR level. Returns
-    user_article_info for the simplified article.
-    """
     from zeeguu.core.llm_services.simplification_and_classification import (
         create_user_specific_simplified_version,
     )
@@ -145,14 +125,10 @@ def article_upload_simplify(upload_id):
     user = User.find_by_id(flask.g.user_id)
     upload = _find_upload_or_404(upload_id, user)
 
-    parent = _promote_upload(upload)
-    if not parent.cefr_assessment or not parent.cefr_assessment.llm_cefr_level:
-        parent.assess_cefr_level(db_session)
-
-    try:
-        user_level = user.cefr_level_for_learned_language()
-    except Exception:
-        user_level = "A2"
+    # Simplification uses user.cefr_level_for_learned_language() as target;
+    # parent CEFR isn't needed, so we skip the 2–10s LLM CEFR call here.
+    parent = _promote_upload_or_abort(upload)
+    user_level = _user_cefr_level(user)
 
     existing = [v for v in parent.simplified_versions if v.cefr_level == user_level]
     simplified = existing[0] if existing else create_user_specific_simplified_version(
@@ -171,12 +147,6 @@ def article_upload_simplify(upload_id):
 @cross_domain
 @requires_session
 def article_upload_translate_and_adapt(upload_id):
-    """
-    Promote the upload, then delegate to the existing translate-and-adapt
-    flow by URL. The existing endpoint caches by URL anyway, so running it
-    on the already-promoted article's URL gives us the same behavior as the
-    share-sheet path.
-    """
     from zeeguu.core.llm_services.simplification_service import SimplificationService
     from zeeguu.core.model import Language
     from zeeguu.core.model.url import Url
@@ -187,15 +157,7 @@ def article_upload_translate_and_adapt(upload_id):
     user = User.find_by_id(flask.g.user_id)
     upload = _find_upload_or_404(upload_id, user)
 
-    parent = _promote_upload(upload)
-    if not parent.cefr_assessment or not parent.cefr_assessment.llm_cefr_level:
-        parent.assess_cefr_level(db_session)
-
-    try:
-        user_level = user.cefr_level_for_learned_language()
-    except Exception:
-        user_level = "A1"
-
+    user_level = _user_cefr_level(user)
     target_language = user.learned_language.code
     source_language = upload.language.code if upload.language else "unknown"
 
@@ -249,8 +211,8 @@ def article_upload_translate_and_adapt(upload_id):
     )
     translated_article.cefr_level = user_level
     translated_article.source_upload_id = upload.id
-    if parent.img_url:
-        translated_article.img_url = parent.img_url
+    if upload.image_url:
+        translated_article.img_url = Url.find_or_create(db_session, upload.image_url)
 
     db_session.add(translated_article)
     db_session.commit()

--- a/zeeguu/api/endpoints/article_upload.py
+++ b/zeeguu/api/endpoints/article_upload.py
@@ -76,7 +76,7 @@ def article_upload_create():
 
     user = User.find_by_id(flask.g.user_id)
 
-    upload = ArticleUpload.create(
+    upload = ArticleUpload.find_or_create(
         db_session,
         user=user,
         url_string=url,

--- a/zeeguu/api/endpoints/article_upload.py
+++ b/zeeguu/api/endpoints/article_upload.py
@@ -119,27 +119,27 @@ def article_upload_promote(upload_id):
 @requires_session
 def article_upload_simplify(upload_id):
     from zeeguu.core.llm_services.simplification_and_classification import (
-        create_user_specific_simplified_version,
+        create_simplified_version_from_upload,
     )
 
     user = User.find_by_id(flask.g.user_id)
     upload = _find_upload_or_404(upload_id, user)
 
-    # Simplification uses user.cefr_level_for_learned_language() as target;
-    # parent CEFR isn't needed, so we skip the 2–10s LLM CEFR call here.
-    parent = _promote_upload_or_abort(upload)
     user_level = _user_cefr_level(user)
 
-    existing = [v for v in parent.simplified_versions if v.cefr_level == user_level]
-    simplified = existing[0] if existing else create_user_specific_simplified_version(
-        db_session, parent, user_level
+    existing = Article.query.filter_by(
+        source_upload_id=upload.id, cefr_level=user_level
+    ).first()
+    simplified = existing or create_simplified_version_from_upload(
+        db_session, upload, user_level
     )
+    if simplified is None:
+        flask.abort(500, "Could not simplify this upload")
 
-    target_article = simplified or parent
-    _ensure_personal_copy(user, target_article)
+    _ensure_personal_copy(user, simplified)
 
     return json_result(
-        UserArticle.user_article_info(user, target_article, with_content=True)
+        UserArticle.user_article_info(user, simplified, with_content=True)
     )
 
 

--- a/zeeguu/api/endpoints/article_upload.py
+++ b/zeeguu/api/endpoints/article_upload.py
@@ -1,0 +1,266 @@
+"""
+Endpoints for ArticleUpload — the lightweight per-user ingestion entity.
+
+The Chrome extension scrapes the page body, POSTs it here to create an
+ArticleUpload, then navigates to /shared-article?upload_id=<id>. The
+SharedArticleHandler fetches upload info and shows the choice modal.
+On the user's choice, one of the derivation endpoints below runs:
+the upload's content becomes a full Article (promoted / simplified /
+translated-and-adapted), PersonalCopy is created, and the client
+navigates to the reader.
+
+See docs/future-work/extension-ingestion-unification.md
+"""
+import flask
+from flask import request
+
+from zeeguu.core.model import Article, ArticleUpload, User
+from zeeguu.core.model.personal_copy import PersonalCopy
+from zeeguu.core.model.user_article import UserArticle
+from zeeguu.api.utils.json_result import json_result
+from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
+
+from . import api, db_session
+
+
+def _find_upload_or_404(upload_id, user):
+    upload = ArticleUpload.find_by_id(upload_id)
+    if not upload:
+        flask.abort(404, "Upload not found")
+    if upload.user_id != user.id:
+        flask.abort(403, "Upload belongs to another user")
+    return upload
+
+
+def _promote_upload(upload):
+    """
+    Promote an upload's raw content into a full Article row, setting
+    source_upload_id as the back-reference. Reuses Article.find_or_create
+    so all existing work (fragments, FK, topics, CEFR) happens exactly once.
+    """
+    return Article.find_or_create(
+        db_session,
+        upload.url.as_string(),
+        html_content=upload.raw_html,
+        text_content=upload.text_content,
+        title=upload.title,
+        author=upload.author,
+        image_url=upload.image_url,
+        source_upload_id=upload.id,
+    )
+
+
+def _ensure_personal_copy(user, article):
+    if not PersonalCopy.exists_for(user, article):
+        PersonalCopy.make_for(user, article, db_session)
+
+
+@api.route("/article_upload/create", methods=["POST"])
+@cross_domain
+@requires_session
+def article_upload_create():
+    """
+    Create a new ArticleUpload from client-scraped content.
+
+    Expects (form):
+      - url (required)
+      - raw_html (optional but typical for extension)
+      - text_content (optional; extension usually sends this too)
+      - title, image_url, author (optional)
+
+    Returns: { upload_id, url, title, language, image_url, author, created_at }
+    """
+    url = request.form.get("url", "").strip()
+    if not url:
+        flask.abort(400, "url required")
+
+    raw_html = request.form.get("raw_html") or None
+    text_content = request.form.get("text_content") or None
+    title = request.form.get("title") or None
+    image_url = request.form.get("image_url") or None
+    author = request.form.get("author") or None
+
+    if not raw_html and not text_content:
+        flask.abort(400, "raw_html or text_content required")
+
+    user = User.find_by_id(flask.g.user_id)
+
+    upload = ArticleUpload.create(
+        db_session,
+        user=user,
+        url_string=url,
+        raw_html=raw_html,
+        text_content=text_content,
+        title=title,
+        image_url=image_url,
+        author=author,
+    )
+    return json_result(upload.as_dictionary())
+
+
+@api.route("/article_upload/<int:upload_id>", methods=["GET"])
+@cross_domain
+@requires_session
+def article_upload_get(upload_id):
+    """Return upload info for the SharedArticleHandler choice modal."""
+    user = User.find_by_id(flask.g.user_id)
+    upload = _find_upload_or_404(upload_id, user)
+    return json_result(upload.as_dictionary())
+
+
+@api.route("/article_upload/<int:upload_id>/promote_to_article", methods=["POST"])
+@cross_domain
+@requires_session
+def article_upload_promote(upload_id):
+    """
+    Read Original / Read As-Is: promote the upload to a full Article and
+    add a PersonalCopy for the user. Returns user_article_info so the
+    client can navigate directly to the reader.
+    """
+    user = User.find_by_id(flask.g.user_id)
+    upload = _find_upload_or_404(upload_id, user)
+
+    article = _promote_upload(upload)
+    if not article.cefr_assessment or not article.cefr_assessment.llm_cefr_level:
+        article.assess_cefr_level(db_session)
+
+    _ensure_personal_copy(user, article)
+
+    return json_result(UserArticle.user_article_info(user, article, with_content=True))
+
+
+@api.route("/article_upload/<int:upload_id>/simplify", methods=["POST"])
+@cross_domain
+@requires_session
+def article_upload_simplify(upload_id):
+    """
+    Promote the upload (so simplification has a parent Article to anchor to)
+    and create a simplified version at the user's CEFR level. Returns
+    user_article_info for the simplified article.
+    """
+    from zeeguu.core.llm_services.simplification_and_classification import (
+        create_user_specific_simplified_version,
+    )
+
+    user = User.find_by_id(flask.g.user_id)
+    upload = _find_upload_or_404(upload_id, user)
+
+    parent = _promote_upload(upload)
+    if not parent.cefr_assessment or not parent.cefr_assessment.llm_cefr_level:
+        parent.assess_cefr_level(db_session)
+
+    try:
+        user_level = user.cefr_level_for_learned_language()
+    except Exception:
+        user_level = "A2"
+
+    existing = [v for v in parent.simplified_versions if v.cefr_level == user_level]
+    simplified = existing[0] if existing else create_user_specific_simplified_version(
+        db_session, parent, user_level
+    )
+
+    target_article = simplified or parent
+    _ensure_personal_copy(user, target_article)
+
+    return json_result(
+        UserArticle.user_article_info(user, target_article, with_content=True)
+    )
+
+
+@api.route("/article_upload/<int:upload_id>/translate_and_adapt", methods=["POST"])
+@cross_domain
+@requires_session
+def article_upload_translate_and_adapt(upload_id):
+    """
+    Promote the upload, then delegate to the existing translate-and-adapt
+    flow by URL. The existing endpoint caches by URL anyway, so running it
+    on the already-promoted article's URL gives us the same behavior as the
+    share-sheet path.
+    """
+    from zeeguu.core.llm_services.simplification_service import SimplificationService
+    from zeeguu.core.model import Language
+    from zeeguu.core.model.url import Url
+    from zeeguu.core.model.source import Source
+    from zeeguu.core.model.source_type import SourceType
+    from datetime import datetime
+
+    user = User.find_by_id(flask.g.user_id)
+    upload = _find_upload_or_404(upload_id, user)
+
+    parent = _promote_upload(upload)
+    if not parent.cefr_assessment or not parent.cefr_assessment.llm_cefr_level:
+        parent.assess_cefr_level(db_session)
+
+    try:
+        user_level = user.cefr_level_for_learned_language()
+    except Exception:
+        user_level = "A1"
+
+    target_language = user.learned_language.code
+    source_language = upload.language.code if upload.language else "unknown"
+
+    translated_url_key = (
+        f"{upload.url.as_string()}"
+        f"#translated-from-{source_language}-to-{target_language}-{user_level}"
+    )
+
+    existing_article = Article.find(translated_url_key)
+    if existing_article:
+        _ensure_personal_copy(user, existing_article)
+        uai = UserArticle.user_article_info(user, existing_article, with_content=True)
+        uai["is_translated"] = True
+        uai["source_language"] = source_language
+        return json_result(uai)
+
+    content = upload.text_content or upload.raw_html or ""
+    title = upload.title or ""
+
+    service = SimplificationService()
+    result = service.translate_and_adapt(
+        title=title,
+        content=content,
+        source_language=source_language,
+        target_language=target_language,
+        target_level=user_level,
+    )
+    if not result:
+        flask.abort(500, "Translation failed")
+
+    translated_url = Url.find_or_create(db_session, translated_url_key)
+    target_lang_obj = Language.find(target_language)
+    source_type = SourceType.find_by_type(SourceType.ARTICLE)
+    source_obj = Source.find_or_create(
+        db_session, result["content"], source_type, target_lang_obj, 0
+    )
+
+    clean_summary = result.get("summary") or (result["content"][:200] + "...")
+
+    translated_article = Article(
+        translated_url,
+        result["title"],
+        None,
+        source_obj,
+        clean_summary,
+        datetime.now(),
+        None,
+        target_lang_obj,
+        result["content"],
+        None,
+    )
+    translated_article.cefr_level = user_level
+    translated_article.source_upload_id = upload.id
+    if parent.img_url:
+        translated_article.img_url = parent.img_url
+
+    db_session.add(translated_article)
+    db_session.commit()
+
+    translated_article.create_article_fragments(db_session)
+    db_session.commit()
+
+    _ensure_personal_copy(user, translated_article)
+
+    uai = UserArticle.user_article_info(user, translated_article, with_content=True)
+    uai["is_translated"] = True
+    uai["source_language"] = source_language
+    return json_result(uai)

--- a/zeeguu/api/endpoints/user_articles.py
+++ b/zeeguu/api/endpoints/user_articles.py
@@ -9,7 +9,6 @@ from zeeguu.core.content_recommender import (
 from zeeguu.core.model import (
     UserArticle,
     Article,
-    ArticleUpload,
     PersonalCopy,
     User,
     UserArticleBrokenReport,
@@ -142,20 +141,6 @@ def saved_articles(page: int = None):
         saves = PersonalCopy.all_for(user)
 
     article_infos = UserArticle.article_infos(user, saves, select_appropriate=True)
-
-    # Client routes is_upload items to /shared-article?upload_id=<id>
-    # instead of /read/article?id=<id>.
-    if page is None or page == 0:
-        saved_upload_ids = {
-            a.source_upload_id for a in saves if a.source_upload_id is not None
-        }
-        uploads = [
-            u for u in ArticleUpload.for_user(user) if u.id not in saved_upload_ids
-        ]
-        for upload in uploads:
-            d = upload.as_dictionary()
-            d["is_upload"] = True
-            article_infos.append(d)
 
     return json_result(article_infos)
 

--- a/zeeguu/api/endpoints/user_articles.py
+++ b/zeeguu/api/endpoints/user_articles.py
@@ -143,10 +143,8 @@ def saved_articles(page: int = None):
 
     article_infos = UserArticle.article_infos(user, saves, select_appropriate=True)
 
-    # Include user's uploads that haven't been promoted+saved yet. Uploads
-    # render as pseudo-article-infos marked with is_upload so the client can
-    # route their click to /shared-article?upload_id=<id> instead of /read.
-    # See docs/future-work/extension-ingestion-unification.md
+    # Client routes is_upload items to /shared-article?upload_id=<id>
+    # instead of /read/article?id=<id>.
     if page is None or page == 0:
         saved_upload_ids = {
             a.source_upload_id for a in saves if a.source_upload_id is not None

--- a/zeeguu/api/endpoints/user_articles.py
+++ b/zeeguu/api/endpoints/user_articles.py
@@ -9,6 +9,7 @@ from zeeguu.core.content_recommender import (
 from zeeguu.core.model import (
     UserArticle,
     Article,
+    ArticleUpload,
     PersonalCopy,
     User,
     UserArticleBrokenReport,
@@ -141,6 +142,22 @@ def saved_articles(page: int = None):
         saves = PersonalCopy.all_for(user)
 
     article_infos = UserArticle.article_infos(user, saves, select_appropriate=True)
+
+    # Include user's uploads that haven't been promoted+saved yet. Uploads
+    # render as pseudo-article-infos marked with is_upload so the client can
+    # route their click to /shared-article?upload_id=<id> instead of /read.
+    # See docs/future-work/extension-ingestion-unification.md
+    if page is None or page == 0:
+        saved_upload_ids = {
+            a.source_upload_id for a in saves if a.source_upload_id is not None
+        }
+        uploads = [
+            u for u in ArticleUpload.for_user(user) if u.id not in saved_upload_ids
+        ]
+        for upload in uploads:
+            d = upload.as_dictionary()
+            d["is_upload"] = True
+            article_infos.append(d)
 
     return json_result(article_infos)
 

--- a/zeeguu/core/llm_services/simplification_and_classification.py
+++ b/zeeguu/core/llm_services/simplification_and_classification.py
@@ -872,6 +872,59 @@ def create_user_specific_simplified_version(session, article, target_level):
         return None
 
 
+def create_simplified_version_from_upload(session, upload, target_level):
+    """
+    Simplify an ArticleUpload directly at target_level. No parent Article
+    is created; the resulting simplified Article stores source_upload_id
+    as the back-reference. Returns the simplified Article or None.
+    """
+    from zeeguu.logging import log
+
+    log(f"Creating simplified article from upload {upload.id} at level {target_level}")
+
+    cefr_order = ["A1", "A2", "B1", "B2", "C1", "C2"]
+    if target_level not in cefr_order:
+        log(f"Invalid target CEFR level: {target_level}")
+        return None
+
+    if not upload.language:
+        log(f"Upload {upload.id} has no detected language; cannot simplify")
+        return None
+
+    content = upload.text_content or upload.raw_html or ""
+    title = upload.title or ""
+    if not content.strip():
+        log(f"Upload {upload.id} has no content to simplify")
+        return None
+
+    try:
+        result = _create_targeted_simplified_version(
+            content,
+            title,
+            upload.language.code,
+            None,  # original_level unknown and unused by the service
+            target_level,
+        )
+        if not result:
+            log(f"Simplification LLM returned nothing for upload {upload.id}")
+            return None
+
+        return Article.create_simplified_version(
+            session=session,
+            source_upload=upload,
+            simplified_title=result["title"],
+            simplified_content=result["content"],
+            simplified_summary=result.get("summary", ""),
+            cefr_level=target_level,
+            ai_model="claude-3-5-sonnet",
+            commit=True,
+        )
+    except Exception as e:
+        log(f"Error simplifying upload {upload.id}: {e}")
+        session.rollback()
+        return None
+
+
 def _create_targeted_simplified_version(
     content, title, language_code, original_level, target_level
 ):

--- a/zeeguu/core/model/__init__.py
+++ b/zeeguu/core/model/__init__.py
@@ -7,6 +7,7 @@ from .url import Url
 from .domain_name import DomainName
 
 from .article import Article
+from .article_upload import ArticleUpload
 from .article_cefr_assessment import ArticleCefrAssessment
 from .article_tokenization_cache import ArticleTokenizationCache
 from .text import Text

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -808,21 +808,47 @@ class Article(db.Model):
     def create_simplified_version(
         cls,
         session,
-        parent_article,
         simplified_title,
         simplified_content,
         simplified_summary,
         cefr_level,
         ai_model,
+        parent_article=None,
+        source_upload=None,
         original_cefr_level=None,
         original_summary=None,
         commit=True,
     ):
         """
-        Creates a simplified version of an article as a new entry in the article table
+        Create a simplified Article row derived from either an existing
+        Article (parent_article) or directly from an ArticleUpload
+        (source_upload). Exactly one of the two must be provided.
         """
         from zeeguu.core.model.source import Source
         from zeeguu.core.model.source_type import SourceType
+        from zeeguu.core.model.url import Url
+        import uuid
+
+        if (parent_article is None) == (source_upload is None):
+            raise ValueError("Provide exactly one of parent_article or source_upload")
+
+        # Derive the ambient fields from whichever source we have.
+        if parent_article is not None:
+            language = parent_article.language
+            published_time = parent_article.published_time
+            feed = parent_article.feed
+            uploader = parent_article.uploader
+            img_url = parent_article.img_url
+        else:
+            language = source_upload.language
+            published_time = source_upload.created_at
+            feed = None
+            uploader = None
+            img_url = (
+                Url.find_or_create(session, source_upload.image_url)
+                if source_upload.image_url
+                else None
+            )
 
         # Normalize Unicode to NFC (precomposed form) - LLMs may return NFD (decomposed)
         # which causes visual rendering issues with diacritics (e.g., Romanian ă, â)
@@ -830,34 +856,24 @@ class Article(db.Model):
         simplified_content = unicodedata.normalize('NFC', simplified_content) if simplified_content else simplified_content
         simplified_summary = unicodedata.normalize('NFC', simplified_summary) if simplified_summary else simplified_summary
 
-        # Create a Source object for the simplified content
         source_type = SourceType.find_by_type(SourceType.ARTICLE)
         simplified_source = Source.find_or_create(
             session,
             simplified_content,
             source_type,
-            parent_article.language,
+            language,
             0,  # broken flag
             commit=False,
         )
 
-        # Create temporary placeholder URL for simplified article
-        # We'll update this to the standard format after the article gets its ID
-        from zeeguu.core.model.url import Url
-        import uuid
-
         placeholder_url_string = f"https://zeeguu.org/simplified/pending/{uuid.uuid4()}"
         placeholder_url = Url.find_or_create(session, placeholder_url_string)
 
-        # Create the simplified article
-        # Check if content is already HTML (from SimplificationService) or needs conversion
         simplified_html = ""
         if simplified_content:
-            # If content starts with HTML tags, it's already been converted
             if simplified_content.strip().startswith("<"):
                 simplified_html = simplified_content
             else:
-                # Convert markdown/plain text to HTML
                 import markdown2
 
                 simplified_html = markdown2.markdown(
@@ -866,55 +882,52 @@ class Article(db.Model):
                 )
 
         simplified_article = cls(
-            placeholder_url,  # Temporary placeholder URL
+            placeholder_url,
             simplified_title,
             "",  # Empty authors field for simplified articles
             simplified_source,
-            simplified_summary,  # Use AI-generated summary
-            parent_article.published_time,
-            parent_article.feed,
-            parent_article.language,
-            simplified_html,  # Use generated HTML from simplified content
-            parent_article.uploader,
+            simplified_summary,
+            published_time,
+            feed,
+            language,
+            simplified_html,
+            uploader,
         )
 
-        # Debug: Ensure summary is set correctly
         if simplified_summary and len(simplified_summary) > 10:
             simplified_article.summary = simplified_summary
             log(
                 f"Set simplified summary ({len(simplified_summary)} chars): {simplified_summary[:100]}..."
             )
 
-        # Set simplified article specific fields
-        simplified_article.parent_article_id = parent_article.id
         simplified_article.cefr_level = cefr_level
+        if parent_article is not None:
+            simplified_article.parent_article_id = parent_article.id
+        if source_upload is not None:
+            simplified_article.source_upload_id = source_upload.id
 
-        # Find or create AI model record
         ai_generator_record = AIGenerator.find_or_create(session, ai_model)
         simplified_article.simplification_ai_generator_id = ai_generator_record.id
 
-        # Inherit image from parent article
-        if parent_article.img_url:
-            simplified_article.img_url = parent_article.img_url
+        if img_url is not None:
+            simplified_article.img_url = img_url
 
-        # Set the original article's CEFR level and summary if provided and not already set
-        if original_cefr_level and not parent_article.cefr_level:
-            parent_article.cefr_level = original_cefr_level
-            session.add(parent_article)
-
-        if original_summary:
-            parent_article.summary = original_summary
-            session.add(parent_article)
+        if parent_article is not None:
+            if original_cefr_level and not parent_article.cefr_level:
+                parent_article.cefr_level = original_cefr_level
+                session.add(parent_article)
+            if original_summary:
+                parent_article.summary = original_summary
+                session.add(parent_article)
 
         session.add(simplified_article)
 
-        # Inherit topics from parent article with same origin type
-        for topic_map in parent_article.topics:
-            simplified_article.add_topic_if_doesnt_exist(
-                topic_map.topic, session, topic_map.origin_type
-            )
+        if parent_article is not None:
+            for topic_map in parent_article.topics:
+                simplified_article.add_topic_if_doesnt_exist(
+                    topic_map.topic, session, topic_map.origin_type
+                )
 
-        # Create article fragments for web display
         simplified_article.create_article_fragments(session)
 
         if commit:

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -165,6 +165,10 @@ class Article(db.Model):
     uploader_id = Column(Integer, ForeignKey(User.id))
     uploader = relationship(User)
 
+    # Set when this article was derived from a user's ArticleUpload
+    # (extension body-scrape or iOS share). Nullable for normal feed articles.
+    source_upload_id = Column(Integer, ForeignKey("article_upload.id"))
+
     topics = relationship(
         "ArticleTopicMap",
         back_populates="article",
@@ -1296,6 +1300,7 @@ class Article(db.Model):
         title=None,
         author=None,
         image_url=None,
+        source_upload_id=None,
     ):
         """
         Find existing article by URL or create new article from URL.
@@ -1389,6 +1394,9 @@ class Article(db.Model):
             language,
             html_content,
         )
+
+        if source_upload_id is not None:
+            new_article.source_upload_id = source_upload_id
 
         session.add(new_article)
 

--- a/zeeguu/core/model/article_upload.py
+++ b/zeeguu/core/model/article_upload.py
@@ -77,8 +77,8 @@ class ArticleUpload(db.Model):
         )
 
     @classmethod
-    def create(cls, session, user, url_string, raw_html, text_content,
-               title=None, image_url=None, author=None):
+    def find_or_create(cls, session, user, url_string, raw_html, text_content,
+                       title=None, image_url=None, author=None):
         detection_basis = (text_content or raw_html or title or "")[:_LANGDETECT_MAX_CHARS]
         try:
             lang_code = detect(detection_basis) if detection_basis else None
@@ -87,6 +87,18 @@ class ArticleUpload(db.Model):
         language = Language.find(lang_code) if lang_code else None
 
         url_obj = Url.find_or_create(session, url_string, title=title or "")
+
+        existing = cls.query.filter_by(user_id=user.id, url_id=url_obj.id).first()
+        if existing:
+            existing.raw_html = raw_html
+            existing.text_content = text_content
+            existing.title = title
+            existing.image_url = image_url
+            existing.author = author
+            existing.language = language
+            session.add(existing)
+            session.commit()
+            return existing
 
         upload = cls(
             user=user,

--- a/zeeguu/core/model/article_upload.py
+++ b/zeeguu/core/model/article_upload.py
@@ -1,4 +1,11 @@
-"""Per-user ingestion entity for extension / share uploads."""
+"""Per-user ingestion entity for extension / share uploads.
+
+We persist the extras the client already extracted with Readability
+(title, image_url, author, language) alongside raw_html/text_content,
+so the choice modal can render a proper preview immediately and the
+conversion endpoint doesn't pay a second readability_server pass when
+deriving the Article.
+"""
 from datetime import datetime
 
 from langdetect import detect

--- a/zeeguu/core/model/article_upload.py
+++ b/zeeguu/core/model/article_upload.py
@@ -1,25 +1,21 @@
-"""
-ArticleUpload — per-user, lightweight ingestion entity.
-
-Created when a user sends an article to Zeeguu from the Chrome extension
-(client-side body scrape) or iOS share sheet. Unlike Article, this entity
-deliberately skips the expensive work: no Stanza tokenization, no FK/CEFR,
-no fragment creation, no topic inference, no Elasticsearch indexing.
-
-An ArticleUpload is promoted to a full Article (or a derived simplified /
-translated-and-adapted Article) only when the user commits to a reading
-choice in SharedArticleHandler. See docs/future-work/extension-ingestion-unification.md
-"""
+"""Per-user ingestion entity for extension / share uploads."""
 from datetime import datetime
 
+from langdetect import detect
+from langdetect.lang_detect_exception import LangDetectException
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import joinedload, relationship
 
 from zeeguu.core.model.db import db
 from zeeguu.core.model.language import Language
 from zeeguu.core.model.url import Url
 from zeeguu.core.model.user import User
+
+# langdetect only needs a few KB; don't feed it full raw_html.
+_LANGDETECT_MAX_CHARS = 4000
+
+_DEFAULT_USER_UPLOADS_LIMIT = 100
 
 
 class ArticleUpload(db.Model):
@@ -65,22 +61,24 @@ class ArticleUpload(db.Model):
         return cls.query.filter_by(id=upload_id).first()
 
     @classmethod
-    def for_user(cls, user):
-        return cls.query.filter_by(user_id=user.id).order_by(cls.created_at.desc()).all()
+    def for_user(cls, user, limit=_DEFAULT_USER_UPLOADS_LIMIT):
+        return (
+            cls.query.options(joinedload(cls.url), joinedload(cls.language))
+            .filter_by(user_id=user.id)
+            .order_by(cls.created_at.desc())
+            .limit(limit)
+            .all()
+        )
 
     @classmethod
     def create(cls, session, user, url_string, raw_html, text_content,
                title=None, image_url=None, author=None):
-        """
-        Detect language cheaply (langdetect only) and persist the upload row.
-        No Stanza, no FK, no fragments — that work is deferred to the moment
-        the user picks a reading choice and we derive an Article.
-        """
-        from langdetect import detect
-
-        detection_basis = text_content or raw_html or title or ""
-        lang_code = detect(detection_basis) if detection_basis else None
-        language = Language.find(lang_code)
+        detection_basis = (text_content or raw_html or title or "")[:_LANGDETECT_MAX_CHARS]
+        try:
+            lang_code = detect(detection_basis) if detection_basis else None
+        except LangDetectException:
+            lang_code = None
+        language = Language.find(lang_code) if lang_code else None
 
         url_obj = Url.find_or_create(session, url_string, title=title or "")
 
@@ -100,7 +98,7 @@ class ArticleUpload(db.Model):
 
     def as_dictionary(self):
         return {
-            "upload_id": self.id,
+            "id": self.id,
             "url": self.url.as_string() if self.url else None,
             "title": self.title,
             "language": self.language.code if self.language else None,

--- a/zeeguu/core/model/article_upload.py
+++ b/zeeguu/core/model/article_upload.py
@@ -3,8 +3,7 @@ from datetime import datetime
 
 from langdetect import detect
 from langdetect.lang_detect_exception import LangDetectException
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
-from sqlalchemy.dialects.mysql import MEDIUMTEXT
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UnicodeText
 from sqlalchemy.orm import joinedload, relationship
 
 from zeeguu.core.model.db import db
@@ -34,8 +33,8 @@ class ArticleUpload(db.Model):
     language = relationship(Language)
 
     title = Column(String(512))
-    raw_html = Column(MEDIUMTEXT)
-    text_content = Column(MEDIUMTEXT)
+    raw_html = Column(UnicodeText())
+    text_content = Column(UnicodeText())
     image_url = Column(String(2048))
     author = Column(String(256))
 

--- a/zeeguu/core/model/article_upload.py
+++ b/zeeguu/core/model/article_upload.py
@@ -1,0 +1,110 @@
+"""
+ArticleUpload — per-user, lightweight ingestion entity.
+
+Created when a user sends an article to Zeeguu from the Chrome extension
+(client-side body scrape) or iOS share sheet. Unlike Article, this entity
+deliberately skips the expensive work: no Stanza tokenization, no FK/CEFR,
+no fragment creation, no topic inference, no Elasticsearch indexing.
+
+An ArticleUpload is promoted to a full Article (or a derived simplified /
+translated-and-adapted Article) only when the user commits to a reading
+choice in SharedArticleHandler. See docs/future-work/extension-ingestion-unification.md
+"""
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.dialects.mysql import MEDIUMTEXT
+from sqlalchemy.orm import relationship
+
+from zeeguu.core.model.db import db
+from zeeguu.core.model.language import Language
+from zeeguu.core.model.url import Url
+from zeeguu.core.model.user import User
+
+
+class ArticleUpload(db.Model):
+    __tablename__ = "article_upload"
+    __table_args__ = {"mysql_collate": "utf8_bin"}
+
+    id = Column(Integer, primary_key=True)
+
+    user_id = Column(Integer, ForeignKey(User.id), nullable=False)
+    user = relationship(User)
+
+    url_id = Column(Integer, ForeignKey(Url.id), nullable=False)
+    url = relationship(Url)
+
+    language_id = Column(Integer, ForeignKey(Language.id), nullable=False)
+    language = relationship(Language)
+
+    title = Column(String(512))
+    raw_html = Column(MEDIUMTEXT)
+    text_content = Column(MEDIUMTEXT)
+    image_url = Column(String(2048))
+    author = Column(String(256))
+
+    created_at = Column(DateTime, nullable=False)
+
+    def __init__(self, user, url, language, title=None, raw_html=None,
+                 text_content=None, image_url=None, author=None):
+        self.user = user
+        self.url = url
+        self.language = language
+        self.title = title
+        self.raw_html = raw_html
+        self.text_content = text_content
+        self.image_url = image_url
+        self.author = author
+        self.created_at = datetime.now()
+
+    def __repr__(self):
+        return f"<ArticleUpload {self.id} user={self.user_id} url={self.url_id}>"
+
+    @classmethod
+    def find_by_id(cls, upload_id):
+        return cls.query.filter_by(id=upload_id).first()
+
+    @classmethod
+    def for_user(cls, user):
+        return cls.query.filter_by(user_id=user.id).order_by(cls.created_at.desc()).all()
+
+    @classmethod
+    def create(cls, session, user, url_string, raw_html, text_content,
+               title=None, image_url=None, author=None):
+        """
+        Detect language cheaply (langdetect only) and persist the upload row.
+        No Stanza, no FK, no fragments — that work is deferred to the moment
+        the user picks a reading choice and we derive an Article.
+        """
+        from langdetect import detect
+
+        detection_basis = text_content or raw_html or title or ""
+        lang_code = detect(detection_basis) if detection_basis else None
+        language = Language.find(lang_code)
+
+        url_obj = Url.find_or_create(session, url_string, title=title or "")
+
+        upload = cls(
+            user=user,
+            url=url_obj,
+            language=language,
+            title=title,
+            raw_html=raw_html,
+            text_content=text_content,
+            image_url=image_url,
+            author=author,
+        )
+        session.add(upload)
+        session.commit()
+        return upload
+
+    def as_dictionary(self):
+        return {
+            "upload_id": self.id,
+            "url": self.url.as_string() if self.url else None,
+            "title": self.title,
+            "language": self.language.code if self.language else None,
+            "image_url": self.image_url,
+            "author": self.author,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }


### PR DESCRIPTION
## Summary
- New per-user \`article_upload\` entity: the extension's body-scrape (and, later, iOS share) lands here first. Langdetect only — no Stanza, no FK, no fragments, no CEFR LLM at ingest time
- Full \`Article\` rows are derived only when the user picks a reading choice in \`SharedArticleHandler\` (simplify / translate-and-adapt / read-original / read-as-is). Each derived article stores a \`source_upload_id\` back-reference
- \`/user_articles/saved\` now unions in the user's uploads (flagged \`is_upload: true\`), so \"My Articles\" covers saves + not-yet-promoted uploads in one list
- Avoids paying full ingestion cost for content nobody ends up reading, and keeps paywalled user-uploaded HTML out of the shared \`article\` table

## Design
[docs/future-work/extension-ingestion-unification.md](../docs/future-work/extension-ingestion-unification.md) — companion frontend/extension PRs land next.

## Test plan
- [ ] Run the migration and confirm \`article_upload\` + \`article.source_upload_id\` exist
- [ ] \`POST /article_upload/create\` with form \`{url, raw_html, text_content, title}\` returns a row
- [ ] \`GET /article_upload/<id>\` returns language + title
- [ ] \`/article_upload/<id>/simplify\` creates a simplified Article linked via parent chain; \`source_upload_id\` is set on the promoted parent
- [ ] \`/article_upload/<id>/promote_to_article\` creates a full Article with \`source_upload_id\` + a PersonalCopy for the user
- [ ] \`/user_articles/saved\` includes the upload (with \`is_upload: true\`) until promoted+saved, then only the promoted article