### PR TITLE
Run readability_server on upload raw_html

### DIFF
--- a/zeeguu/api/endpoints/article_upload.py
+++ b/zeeguu/api/endpoints/article_upload.py
@@ -8,10 +8,37 @@ from zeeguu.core.model.personal_copy import PersonalCopy
 from zeeguu.core.model.user_article import UserArticle
 from zeeguu.api.utils.json_result import json_result
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
+from zeeguu.logging import log
 
 from . import api, db_session
 
 _DEFAULT_CEFR_LEVEL = "A2"
+
+
+def _extract_with_readability_server(url, raw_html):
+    """
+    Run the readability_server on raw_html and return a dict with
+    cleaned {title, text, image_url, author, language_code}, or None
+    if extraction fails. Never raises; callers fall back to client hints.
+    """
+    from zeeguu.core.content_retriever import readability_download_and_parse
+    from zeeguu.core.content_retriever.article_downloader import extract_article_image
+
+    try:
+        np_article = readability_download_and_parse(url, html_content=raw_html)
+    except Exception as e:
+        log(f"readability_server extraction failed for {url}: {e}")
+        return None
+
+    image = extract_article_image(np_article) or None
+
+    return {
+        "title": np_article.title or None,
+        "text": np_article.text or None,
+        "image_url": image,
+        "author": ", ".join(np_article.authors) if np_article.authors else None,
+        "language_code": np_article.meta_lang or None,
+    }
 
 
 def _find_upload_or_404(upload_id, user):
@@ -66,13 +93,26 @@ def article_upload_create():
         flask.abort(400, "url required")
 
     raw_html = request.form.get("raw_html") or None
-    text_content = request.form.get("text_content") or None
-    title = request.form.get("title") or None
-    image_url = request.form.get("image_url") or None
-    author = request.form.get("author") or None
+    client_text = request.form.get("text_content") or None
+    client_title = request.form.get("title") or None
+    client_image = request.form.get("image_url") or None
+    client_author = request.form.get("author") or None
 
-    if not raw_html and not text_content:
+    if not raw_html and not client_text:
         flask.abort(400, "raw_html or text_content required")
+
+    # Prefer server-side extraction so uploads match the metadata quality
+    # (title, image, summary basis, author, language) the crawler produces.
+    # Fall back to client-provided hints if readability_server is unreachable
+    # or the page can't be cleanly parsed.
+    server_extracted = _extract_with_readability_server(url, raw_html) if raw_html else None
+    if server_extracted:
+        text_content = server_extracted["text"] or client_text
+        title = server_extracted["title"] or client_title
+        image_url = server_extracted["image_url"] or client_image
+        author = server_extracted["author"] or client_author
+    else:
+        text_content, title, image_url, author = client_text, client_title, client_image, client_author
 
     user = User.find_by_id(flask.g.user_id)
 

--- a/zeeguu/api/endpoints/article_upload.py
+++ b/zeeguu/api/endpoints/article_upload.py
@@ -16,11 +16,8 @@ _DEFAULT_CEFR_LEVEL = "A2"
 
 
 def _extract_with_readability_server(url, raw_html):
-    """
-    Run the readability_server on raw_html and return a dict with
-    cleaned {title, text, image_url, author, language_code}, or None
-    if extraction fails. Never raises; callers fall back to client hints.
-    """
+    """Never raises; callers fall back to client hints."""
+    from sentry_sdk import capture_exception
     from zeeguu.core.content_retriever import readability_download_and_parse
     from zeeguu.core.content_retriever.article_downloader import extract_article_image
 
@@ -28,14 +25,13 @@ def _extract_with_readability_server(url, raw_html):
         np_article = readability_download_and_parse(url, html_content=raw_html)
     except Exception as e:
         log(f"readability_server extraction failed for {url}: {e}")
+        capture_exception(e)
         return None
-
-    image = extract_article_image(np_article) or None
 
     return {
         "title": np_article.title or None,
         "text": np_article.text or None,
-        "image_url": image,
+        "image_url": extract_article_image(np_article) or None,
         "author": ", ".join(np_article.authors) if np_article.authors else None,
         "language_code": np_article.meta_lang or None,
     }
@@ -88,6 +84,8 @@ def _ensure_personal_copy(user, article):
 @cross_domain
 @requires_session
 def article_upload_create():
+    from zeeguu.core.model.url import Url
+
     url = request.form.get("url", "").strip()
     if not url:
         flask.abort(400, "url required")
@@ -101,30 +99,30 @@ def article_upload_create():
     if not raw_html and not client_text:
         flask.abort(400, "raw_html or text_content required")
 
-    # Prefer server-side extraction so uploads match the metadata quality
-    # (title, image, summary basis, author, language) the crawler produces.
-    # Fall back to client-provided hints if readability_server is unreachable
-    # or the page can't be cleanly parsed.
-    server_extracted = _extract_with_readability_server(url, raw_html) if raw_html else None
-    if server_extracted:
-        text_content = server_extracted["text"] or client_text
-        title = server_extracted["title"] or client_title
-        image_url = server_extracted["image_url"] or client_image
-        author = server_extracted["author"] or client_author
-    else:
-        text_content, title, image_url, author = client_text, client_title, client_image, client_author
-
     user = User.find_by_id(flask.g.user_id)
+
+    # Short-circuit re-sends: the existing upload already went through
+    # readability_server on first creation, so we avoid paying for that
+    # roundtrip again when the user clicks the extension on a page they've
+    # already sent in.
+    url_obj = Url.find_or_create(db_session, url, title=client_title or "")
+    existing = ArticleUpload.query.filter_by(user_id=user.id, url_id=url_obj.id).first()
+    if existing:
+        return json_result(existing.as_dictionary())
+
+    server = _extract_with_readability_server(url, raw_html) if raw_html else {}
+    server = server or {}
 
     upload = ArticleUpload.find_or_create(
         db_session,
         user=user,
         url_string=url,
         raw_html=raw_html,
-        text_content=text_content,
-        title=title,
-        image_url=image_url,
-        author=author,
+        text_content=server.get("text") or client_text,
+        title=server.get("title") or client_title,
+        image_url=server.get("image_url") or client_image,
+        author=server.get("author") or client_author,
+        language_code=server.get("language_code"),
     )
     return json_result(upload.as_dictionary())
 

--- a/zeeguu/core/model/article_upload.py
+++ b/zeeguu/core/model/article_upload.py
@@ -78,12 +78,14 @@ class ArticleUpload(db.Model):
 
     @classmethod
     def find_or_create(cls, session, user, url_string, raw_html, text_content,
-                       title=None, image_url=None, author=None):
-        detection_basis = (text_content or raw_html or title or "")[:_LANGDETECT_MAX_CHARS]
-        try:
-            lang_code = detect(detection_basis) if detection_basis else None
-        except LangDetectException:
-            lang_code = None
+                       title=None, image_url=None, author=None, language_code=None):
+        lang_code = language_code
+        if not lang_code:
+            detection_basis = (text_content or raw_html or title or "")[:_LANGDETECT_MAX_CHARS]
+            try:
+                lang_code = detect(detection_basis) if detection_basis else None
+            except LangDetectException:
+                lang_code = None
         language = Language.find(lang_code) if lang_code else None
 
         url_obj = Url.find_or_create(session, url_string, title=title or "")


### PR DESCRIPTION
## Summary
- \`/article_upload/create\` now runs \`readability_server\` on the client-sent \`raw_html\` and uses its cleaned output (title, text, image, byline, language) in preference to the client's Readability.js hints.
- Fixes the divergence between extension-ingested and crawler-ingested articles: missing images, summaries with leftover \`<p>\` / \`<strong>\` tags, inconsistent titles.
- Client-provided values remain as fallback if the readability_server is unreachable or the page can't be parsed.
- Follow-up to [#537](https://github.com/zeeguu/api/pull/537).

## Cost
One ~1-3s readability_server roundtrip per upload. Upload creation is already user-waited (popup shows "Sending to Zeeguu…" before the new-tab handoff), so this lands in the noise.

## Test plan
- [ ] Send a news article via the extension — confirm the derived simplified article now has an image and a clean summary
- [ ] Send a page readability_server can't parse — confirm the upload still lands with whatever metadata the client provided
- [ ] Re-send the same URL — \`find_or_create\` on the upload still dedups to the existing row