### PR TITLE
Return img_url from /detect_article_info

### DIFF
--- a/zeeguu/api/endpoints/article.py
+++ b/zeeguu/api/endpoints/article.py
@@ -120,6 +120,7 @@ def detect_article_info():
             "language": existing.language.code,
             "title": existing.title,
             "url": canonical_url,
+            "img_url": existing.img_url.as_string() if existing.img_url else None,
             "exists": True,
         })
 
@@ -135,6 +136,7 @@ def detect_article_info():
             "language": lang,
             "title": title,
             "url": canonical_url,
+            "img_url": np_article.top_image or None,
             "exists": False,
         })
     except Exception as e:


### PR DESCRIPTION
## Summary
- `/detect_article_info` now returns `img_url` alongside `language`/`title`/`url`
- Existing articles: uses the stored `img_url` (via the `Url` relationship)
- Fresh parses: falls back to `newspaper`'s `top_image`

## Why
The web share-flow (`SharedArticleHandler` → `ArticleLanguageModal`) currently shows only the title in the language-choice modal. Returning the hero image lets the frontend render a preview image above the title so users get visual confirmation they're about to simplify/translate the right article.

Frontend change that consumes this is in the web repo.

## Test plan
- [ ] Share a known article (already in DB) → response includes `img_url`
- [ ] Share a URL not in DB → response includes `img_url` from newspaper's `top_image`
- [ ] Share an article with no image → response returns `img_url: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)