### PR TITLE
Add always_open_externally feature flag

### DIFF
--- a/zeeguu/core/user_feature_toggles.py
+++ b/zeeguu/core/user_feature_toggles.py
@@ -17,6 +17,7 @@ def _feature_map():
         "daily_feedback": _daily_feedback,
         "hide_recommendations": _hide_recommendations,
         "show_non_simplified_articles": _show_non_simplified_articles,
+        "always_open_externally": _always_open_externally,
     }
 
 
@@ -78,6 +79,22 @@ def _show_non_simplified_articles(user):
     """
     LEGACY_USER_IDS = {4607, 4626}
     return user.id in LEGACY_USER_IDS
+
+
+def _always_open_externally(user):
+    """Article cards in the feed always render the "Open Externally"
+    button for these users — except for saved articles, which still
+    open in the Zeeguu reader.
+
+    Click-through behavior is unchanged: the redirect-notification modal
+    still appears unless the user has dismissed it with "don't show again".
+
+    Initial rollout: internal devs testing the external-first flow. Once
+    validated we'll likely expose this as a user-facing setting instead of a
+    hardcoded flag.
+    """
+    BETA_USER_IDS = {4607}
+    return user.id in BETA_USER_IDS
 
 
 def _hide_recommendations(user):


### PR DESCRIPTION
## Summary
New detector `_always_open_externally` in `user_feature_toggles.py` that gates a web-side routing change by a hardcoded beta-tester ID list. Follows the same pattern as `_show_non_simplified_articles`.

## Why a feature flag, not a user preference
Simpler for the initial rollout — no DB changes, no settings UI, no backfill. Once the external-first flow is validated, we can either promote to a user-setting or remove the flag and make the behavior default.

## ⚠️ Before merging
The `BETA_USER_IDS` set is empty. Add dev IDs (starting with Mircea's) before this ships, otherwise the flag is a no-op.

## Companion PR
[zeeguu/web#1049](https://github.com/zeeguu/web/pull/1049) — consumes the flag via `Feature.always_open_externally()` in the articles-feed routing.

## Test plan
- [ ] Add your own user ID to `BETA_USER_IDS`, call `/get_user_details`, confirm `features` array contains `"always_open_externally"`
- [ ] Remove ID, call again → feature name absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)