### PR TITLE
Tiered username generation + active-first backfill partition

### DIFF
--- a/tools/migrations/26-02-24-b--add_username.py
+++ b/tools/migrations/26-02-24-b--add_username.py
@@ -1,71 +1,149 @@
 #!/usr/bin/env python
 """
-Migration script to automatically populate usernames for existing users.
+Migration script to back-fill usernames for existing users.
 
-The usernames are generated in the format 'adjective_animal1234' (e.g., 'brave_tiger5678')
-and are guaranteed to be unique across the user base.
-A corresponding user avatar is also generated based on the animal in the username.
-This script should be run after the database schema has been updated to include the new 'username' column in the 'user' table.
+Why two strategies (active vs. inactive)?
+-----------------------------------------
+We have ~200 MAU out of several thousand total accounts. The small "pretty"
+username pool — ADJECTIVES x ANIMALS = 20 x 18 = 360 no-digit combos — is a
+scarce, renewable resource we'd rather spend on users who will actually see
+their username in the UI (leaderboards, friend lists, profile). If we let the
+migration greedily assign `adjective_animal` pairs to everyone in row order,
+the pool evaporates before the active users even log in, and future signups
+immediately spill into 4-digit suffixes.
 
-26-02-24-a--add_username.sql should have been run first to add the 'username' column to the 'user' table.
+So we partition by `last_seen`:
 
-Run with: pip install -e . && python tools/migrations/26-02-24-b--add_username.py
+    * Active in the last 60 days -> prefer_no_digit=True  (tiered: no-digit
+      first, then 1-digit, 2-digit, ... — see User.generate_unique_username)
+    * Everyone else              -> prefer_no_digit=False (skip straight to
+      4-digit; they can rename themselves later if they return)
 
-You might have to run this before: 
-set -a 
-source .env
-set +a
-to set the environment variables before running the script.
+Processing order matters: we handle the active partition first so it claims
+the scarce no-digit pool before the inactive partition runs. The inactive
+partition can't consume it anyway (prefer_no_digit=False jumps to tier 4),
+but running active-first also makes the logs read in the expected order.
+
+Running this script
+-------------------
+Must be run AFTER 26-02-24-a--add_username.sql (nullable column added).
+Then 26-02-24-c--add_username.sql enforces NOT NULL + UNIQUE.
+
+    pip install -e .
+    set -a; source .env; set +a
+    python tools/migrations/26-02-24-b--add_username.py
 """
-from datetime import datetime
+from datetime import datetime, timedelta
 from zeeguu.core.model.user_avatar import UserAvatar
 from zeeguu.core.model.user import User
 
 
-def populate_usernames():
-    # Only query users who don't have a username set (i.e., those with username == None)
-    users: list[User] = User.query.filter(User.username.is_(None)).all()
-    total = len(users)
-    print(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]} Found {total} users without usernames. Populating now...")
+ACTIVE_WINDOW_DAYS = 60
 
-    # Track usernames assigned in this run but not yet committed, so we don't
-    # hand the same username to two users when the UNIQUE constraint isn't yet
-    # enforced and intermediate assignments are invisible to DB checks.
-    assigned_in_session: set[str] = set()
+
+def _now_str():
+    return datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+
+
+def _assign(users: list[User], *, prefer_no_digit: bool, assigned_in_session: set[str], label: str):
+    """Assign usernames + avatars for a partition of users. Returns avatar count."""
+    total = len(users)
     avatar_count = 0
-    
     for i, user in enumerate(users, 1):
-        generated_username, animal = User.generate_unique_username(exclude=assigned_in_session)
+        generated_username, animal = User.generate_unique_username(
+            exclude=assigned_in_session,
+            prefer_no_digit=prefer_no_digit,
+        )
         assigned_in_session.add(generated_username)
         user.username = generated_username
         avatar_created = False
-        # If the user doesn't have an avatar, create one based on the animal in the username.
+        animal_color = background_color = None
+        # Create a matching avatar only if the user doesn't already have one.
         if UserAvatar.find(user.id) is None:
             animal_color, background_color = UserAvatar.random_colors()
             db.session.add(UserAvatar(user.id, animal, animal_color, background_color))
             avatar_created = True
             avatar_count += 1
-        print(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]} [{i}/{total}] user_id={user.id} -> username='{generated_username}' (avatar={'created(' + animal_color + '/' + background_color + ')' if avatar_created else 'exists'})")
-    # Commit all changes to the database at once after processing all users
-    # This is more efficient about 2-3x faster than comitting each user in the loop
+        avatar_info = (
+            f"created({animal_color}/{background_color})" if avatar_created else "exists"
+        )
+        print(
+            f"{_now_str()} [{label} {i}/{total}] user_id={user.id} "
+            f"-> username='{generated_username}' (avatar={avatar_info})"
+        )
+    return avatar_count
+
+
+def populate_usernames():
+    # Pull only users that actually need a username. We keep this as two
+    # separate queries (rather than one + Python partition) so the active-vs-
+    # inactive split is visible in the log line and so an interrupted run
+    # restarts cleanly at the partition we were in.
+    cutoff = datetime.now() - timedelta(days=ACTIVE_WINDOW_DAYS)
+
+    active_users: list[User] = (
+        User.query
+        .filter(User.username.is_(None))
+        .filter(User.last_seen.isnot(None))
+        .filter(User.last_seen >= cutoff)
+        .order_by(User.last_seen.desc())  # most recent first — nice names go to most engaged
+        .all()
+    )
+    inactive_users: list[User] = (
+        User.query
+        .filter(User.username.is_(None))
+        .filter((User.last_seen.is_(None)) | (User.last_seen < cutoff))
+        .all()
+    )
+
+    total = len(active_users) + len(inactive_users)
+    print(
+        f"{_now_str()} Found {total} users without usernames "
+        f"({len(active_users)} active in last {ACTIVE_WINDOW_DAYS}d, "
+        f"{len(inactive_users)} inactive). Populating now..."
+    )
+
+    # Track usernames assigned in this run but not yet committed, so we don't
+    # hand the same username to two users while the UNIQUE constraint is not
+    # yet in place (it lands in step c).
+    assigned_in_session: set[str] = set()
+
+    avatar_count = _assign(
+        active_users,
+        prefer_no_digit=True,
+        assigned_in_session=assigned_in_session,
+        label="active",
+    )
+    avatar_count += _assign(
+        inactive_users,
+        prefer_no_digit=False,
+        assigned_in_session=assigned_in_session,
+        label="inactive",
+    )
+
+    # One commit at the end is 2-3x faster than committing per user.
     db.session.commit()
-    print(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]} Done. Assigned {total} usernames, created {avatar_count} avatars.")
+    print(
+        f"{_now_str()} Done. Assigned {total} usernames "
+        f"({len(active_users)} pretty / {len(inactive_users)} 4-digit), "
+        f"created {avatar_count} avatars."
+    )
 
 
 if __name__ == "__main__":
     from zeeguu.api.app import create_app
     from zeeguu.core.model import db
-    
+
     app = create_app()
     app.app_context().push()
-    start_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+    start_time = _now_str()
     print(f"{start_time} {'='*60}")
     print(f"{start_time} STARTING - username population...")
-    try: 
+    try:
         populate_usernames()
     except Exception as e:
-        print(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]} ERROR during username population: {e}")
-    end_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+        print(f"{_now_str()} ERROR during username population: {e}")
+    end_time = _now_str()
     total_time = datetime.strptime(end_time, '%Y-%m-%d %H:%M:%S.%f') - datetime.strptime(start_time, '%Y-%m-%d %H:%M:%S.%f')
     print(f"{end_time} COMPLETED - username population. Total time: {total_time.seconds}s {total_time.microseconds // 1000}ms.")
     print(f"{end_time} {'='*60}")

--- a/zeeguu/core/account_management/user_account_creation.py
+++ b/zeeguu/core/account_management/user_account_creation.py
@@ -10,6 +10,65 @@ from zeeguu.core.model.unique_code import UniqueCode
 from zeeguu.logging import log
 
 
+# How many times to retry the User INSERT when the username UNIQUE constraint
+# fires because of a concurrent signup. See _commit_new_user_with_retry.
+_USERNAME_RETRY_ATTEMPTS = 3
+
+
+def _commit_new_user_with_retry(db_session, build_user, extra_adds=None):
+    """
+    Add and commit a new User row, retrying with a freshly-generated username
+    on username UNIQUE collisions.
+
+    Background: User.generate_unique_username() does a SELECT before returning
+    to check that its pick is free, but there is a microscopic window between
+    that check and the commit during which a concurrent signup could grab the
+    same name. At current signup volume (~20/month) this is near-zero, but the
+    cost of hardening is a tight loop around build+commit.
+
+    Email collisions are NOT retried — a duplicate email indicates a real
+    conflict, not a transient race, and re-generating a username won't help.
+
+    Args:
+        build_user: zero-arg callable returning (new_user, animal). Called
+            fresh each attempt so the username is regenerated.
+        extra_adds: optional callable taking `new_user` that adds sibling
+            rows (e.g. Teacher) to the same transaction.
+
+    Returns:
+        (new_user, animal) once the commit succeeds.
+
+    Raises:
+        sqlalchemy.exc.IntegrityError if the email is the real conflict, or
+        after _USERNAME_RETRY_ATTEMPTS collisions in a row.
+    """
+    last_error = None
+    for _ in range(_USERNAME_RETRY_ATTEMPTS):
+        # Capture the email up-front: if an IntegrityError fires from inside
+        # extra_adds (some helpers like add_user_to_cohort and
+        # UserLanguage.find_or_create commit internally, so the race can
+        # materialize before our own commit() line), we still need to know
+        # what email we were trying to register.
+        attempted_email = None
+        try:
+            new_user, animal = build_user()
+            attempted_email = new_user.email
+            db_session.add(new_user)
+            if extra_adds is not None:
+                extra_adds(new_user)
+            db_session.commit()
+            return new_user, animal
+        except sqlalchemy.exc.IntegrityError as e:
+            db_session.rollback()
+            last_error = e
+            # Re-checking email_exists (rather than parsing the driver error)
+            # keeps this portable across MySQL driver versions.
+            if attempted_email is not None and User.email_exists(attempted_email):
+                raise
+            # Otherwise assume it's the username UNIQUE and loop.
+    raise last_error
+
+
 def _normalize_username(username):
     return username.strip() if username else username
 
@@ -77,36 +136,35 @@ def create_account(
     try:
         learned_language = Language.find_or_create(learned_language_code)
         native_language = Language.find_or_create(native_language_code)
-        generated_username, animal = User.generate_unique_username()
-        new_user = User(
-            email,
-            username,
-            password,
-            username=generated_username,
-            invitation_code=invite_code,
-            learned_language=learned_language,
-            native_language=native_language,
-            creation_platform=creation_platform,
-        )
-        new_user.email_verified = False  # Require email verification
-        db_session.add(new_user)
-        if cohort_name != "":
-            new_user.add_user_to_cohort(cohort, db_session)
-        new_user.create_default_user_preference()
-        learned_language = UserLanguage.find_or_create(
-            db_session, new_user, learned_language
-        )
-        learned_language.cefr_level = int(learned_cefr_level)
-        learned_language.declared_level_min = 0
-        learned_language.declared_level_max = 11
 
-        db_session.add(learned_language)
+        def build_user():
+            generated_username, animal = User.generate_unique_username()
+            user = User(
+                email,
+                username,
+                password,
+                username=generated_username,
+                invitation_code=invite_code,
+                learned_language=learned_language,
+                native_language=native_language,
+                creation_platform=creation_platform,
+            )
+            user.email_verified = False  # Require email verification
+            return user, animal
 
-        if cohort and cohort.is_cohort_of_teachers:
-            teacher = Teacher(new_user)
-            db_session.add(teacher)
+        def add_siblings(user):
+            if cohort_name != "":
+                user.add_user_to_cohort(cohort, db_session)
+            user.create_default_user_preference()
+            user_language = UserLanguage.find_or_create(db_session, user, learned_language)
+            user_language.cefr_level = int(learned_cefr_level)
+            user_language.declared_level_min = 0
+            user_language.declared_level_max = 11
+            db_session.add(user_language)
+            if cohort and cohort.is_cohort_of_teachers:
+                db_session.add(Teacher(user))
 
-        db_session.commit()
+        new_user, animal = _commit_new_user_with_retry(db_session, build_user, add_siblings)
 
         # TODO Only run this if username is not provided, but rather auto-generated. Implement it when username is implemented
         character_color, background_color = UserAvatar.random_colors()
@@ -161,24 +219,24 @@ def create_basic_account(
                 "No more places in this class. Please contact us (zeeguu.team@gmail.com)."
             )
     try:
-        generated_username, animal = User.generate_unique_username()
-        new_user = User(
-            email,
-            username,
-            password,
-            generated_username,
-            invitation_code=invite_code,
-            creation_platform=creation_platform,
-        )
-        new_user.email_verified = False  # Require email verification
+        def build_user():
+            generated_username, animal = User.generate_unique_username()
+            user = User(
+                email,
+                username,
+                password,
+                generated_username,
+                invitation_code=invite_code,
+                creation_platform=creation_platform,
+            )
+            user.email_verified = False  # Require email verification
+            return user, animal
 
-        db_session.add(new_user)
+        def add_siblings(user):
+            if cohort and cohort.is_cohort_of_teachers:
+                db_session.add(Teacher(user))
 
-        if cohort and cohort.is_cohort_of_teachers:
-            teacher = Teacher(new_user)
-            db_session.add(teacher)
-
-        db_session.commit()
+        new_user, animal = _commit_new_user_with_retry(db_session, build_user, add_siblings)
 
         # TODO Only run this if username is not provided, but rather auto-generated. Implement it when username is implemented
         character_color, background_color = UserAvatar.random_colors()

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -103,31 +103,77 @@ class User(db.Model):
         "leopard", "cheetah", "badger", "beaver", "lynx", "moose"
     ]
 
+    # Legacy ceiling, retained for backwards compat with callers that still
+    # read it (e.g. tests). The tiered generator below uses its own per-tier
+    # suffix ranges rather than a single flat cap.
     MAX_NUMBER_USERNAME = 9999
 
+    # Suffix-width tiers tried, in order, when prefer_no_digit=True.
+    # None means "no suffix at all". Each numeric value is the inclusive
+    # upper bound for random.randint(0, value).
+    _USERNAME_TIERS_PRETTY = (None, 9, 99, 999, 9999)
+    # When prefer_no_digit=False, we skip straight to 4 digits — used for
+    # backfilling inactive accounts so we don't consume the small no-digit
+    # pool (see generate_unique_username docstring).
+    _USERNAME_TIERS_FALLBACK = (9999,)
+
     @classmethod
-    def generate_unique_username(cls, exclude: set = None):
+    def generate_unique_username(cls, exclude: set = None, prefer_no_digit: bool = True):
         """
-        Generate a random unique username in the format 'adjective_animal1234'.
-        Can currently generate 20 x 18 x 9999 = 3,598,200 unique usernames.
+        Generate a random unique username in the format 'adjective_animal[digits]'.
+
+        We try tiers in order from most-readable to least-readable:
+            tier 0: no digit       (e.g. 'clever_otter')     — 20 x 18 = 360 combos
+            tier 1: 1 digit  0..9  (e.g. 'clever_otter7')    — 3,600 combos
+            tier 2: 2 digits 0..99 (e.g. 'clever_otter42')   — 36,000 combos
+            tier 3: 3 digits       (e.g. 'clever_otter500')  — 360,000 combos
+            tier 4: 4 digits       (e.g. 'clever_otter5678') — 3,600,000 combos
+
+        When `prefer_no_digit=True` (the default), we start at tier 0 and only
+        escalate when a tier can't find a free slot. This keeps usernames short
+        and memorable for users who will actually see them in the UI.
+
+        When `prefer_no_digit=False`, we jump straight to tier 4 (4-digit suffix).
+        The backfill migration uses this for inactive accounts so that the small
+        no-digit pool (360 names) is reserved for MAUs and future signups rather
+        than being consumed by dormant users who may never log in again.
 
         Args:
             exclude: optional set of usernames already reserved in the current
-                     session but not yet committed (e.g. during bulk migrations).
+                     session but not yet committed — e.g. the bulk migration
+                     assigns usernames before the UNIQUE constraint exists, so
+                     mid-run picks aren't visible to DB checks yet.
+            prefer_no_digit: start at tier 0 (default) or skip to tier 4.
 
         Returns:
-            username: The generated username.
-            animal: The animal that was used to generate the username.
+            (username, animal) tuple. The animal is returned separately so
+            callers can pick the matching avatar SVG.
         """
-        while True:
-            adjective = random.choice(cls.ADJECTIVES)
-            animal = random.choice(cls.ANIMALS)
-            number = random.randint(1, cls.MAX_NUMBER_USERNAME)
-            username = f"{adjective}_{animal}{number}"
-            if exclude and username in exclude:
-                continue
-            if not User.query.filter_by(username=username).first():
-                return username, animal
+        exclude = exclude or set()
+        tiers = cls._USERNAME_TIERS_PRETTY if prefer_no_digit else cls._USERNAME_TIERS_FALLBACK
+        pair_count = len(cls.ADJECTIVES) * len(cls.ANIMALS)
+
+        for suffix_max in tiers:
+            # 4x pair_count attempts is overkill for tiers 1..4 (they have
+            # 10x..10000x more slots than pair_count) and gives tier 0 a
+            # reasonable chance to surface a free name even when the tier is
+            # nearly full. If we still can't find one, we fall through to
+            # the next tier rather than loop forever.
+            for _ in range(pair_count * 4):
+                adjective = random.choice(cls.ADJECTIVES)
+                animal = random.choice(cls.ANIMALS)
+                if suffix_max is None:
+                    username = f"{adjective}_{animal}"
+                else:
+                    username = f"{adjective}_{animal}{random.randint(0, suffix_max)}"
+                if username in exclude:
+                    continue
+                if not cls.query.filter_by(username=username).first():
+                    return username, animal
+
+        raise RuntimeError(
+            "Username space exhausted across all tiers — expand ADJECTIVES/ANIMALS."
+        )
 
     @classmethod
     def create_anonymous(


### PR DESCRIPTION
## Why this exists

The current generator produces usernames like `brave_tiger5678`. They are guaranteed unique, but the four-digit suffix makes every account look like a throwaway handle on leaderboards, friend lists, and profiles. This PR switches to a tiered generator so new accounts — and the accounts that actually use the product — get pretty names like `brave_tiger`, falling back to small suffixes only when the no-digit pool is saturated.

### The numbers

- `ADJECTIVES` (20) × `ANIMALS` (18) = **360 no-digit pairs**.
- We have **~200 MAUs** out of several thousand total accounts.
- At **~20 new signups / month**, the no-digit pool alone lasts a long time *if it isn't eaten by inactive users during the backfill*.

That last point is the whole reason for the "active-first" partition in the migration: if we let the backfill greedily assign `adjective_animal` pairs in DB row order, the 360 pretty slots evaporate before the MAUs even log in, and every new signup post-deploy immediately spills into 4-digit suffixes.

## What changes

### `User.generate_unique_username(prefer_no_digit=True)`

Now tries tiers in order, escalating only when the current tier can't find a free slot:

| Tier | Pattern                | Combos    | Example            |
| ---- | ---------------------- | --------- | ------------------ |
| 0    | `adjective_animal`     | 360       | `clever_otter`     |
| 1    | `adjective_animal[0-9]`| 3,600     | `clever_otter7`    |
| 2    | `adjective_animal[00-99]`| 36,000  | `clever_otter42`   |
| 3    | `adjective_animal[000-999]`| 360,000 | `clever_otter500` |
| 4    | `adjective_animal[0000-9999]` | 3,600,000 | `clever_otter5678` |

`prefer_no_digit=False` skips straight to tier 4 — used by the migration for inactive users so they don't consume the small tier-0 pool.

### `26-02-24-b--add_username.py`

Partitions users by `last_seen`:

- **Active** (`last_seen` within 60 days) → `prefer_no_digit=True`, processed first so they claim the no-digit pool.
- **Everyone else** → `prefer_no_digit=False`, straight to 4-digit.

`ACTIVE_WINDOW_DAYS = 60` is at the top of the file — easy to tune if we decide a different cutoff.

### `create_account` / `create_basic_account`

Wrapped the user-row INSERT in a small retry helper (`_commit_new_user_with_retry`) that distinguishes a username UNIQUE collision (retry with a fresh name) from an email UNIQUE collision (don't retry — real duplicate). At ~20 signups/month the race probability between two concurrent new users picking the same random name is near zero, but hardening is cheap: 3 retries, fresh generator call per attempt, email conflicts bubble unchanged.

## What we explicitly decided NOT to do

- **Expanding `ADJECTIVES` / `ANIMALS`.** Each animal needs a matching SVG in `web/public/static/avatars/` and an entry in `src/profile/avatarOptions.js`, so growing the pool requires new art, not just code. Out of scope here.
- **Lazy initialization on login.** We discussed assigning usernames on first login instead of bulk-backfilling. Still a valid option, but this PR keeps the backfill to close out the existing migration plan (`a` → `b` → `c` with NOT NULL + UNIQUE). If we want to pivot to lazy later, it's a follow-up.
- **Hardening `add_anon_user`.** The anonymous signup flow in `accounts.py` also calls `generate_unique_username` but has its own error path and is lower-risk (one-off UUID-scoped accounts). Left as-is intentionally; we can harden it in a follow-up if needed.

## Test plan
- [x] `pytest zeeguu/api/test/test_account_creation.py zeeguu/api/test/test_username.py` — all 34 tests green locally
- [ ] Run the migration against a staging DB and spot-check: do the last N users (ordered by `last_seen DESC`) have no-digit usernames? Do older users have 4-digit ones?
- [ ] Check a signup post-deploy and confirm the new account gets a no-digit name (it should — pool is barely consumed)
- [ ] Optional: synthesize a collision by preseeding the DB with every `adjective_animal` pair and confirm the generator gracefully falls back to tier 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)