### PR TITLE
Fix account upgrade for anonymous users. Not setting email as name

### DIFF
--- a/zeeguu/api/endpoints/accounts.py
+++ b/zeeguu/api/endpoints/accounts.py
@@ -264,7 +264,7 @@ def complete_account_upgrade():
 
     try:
         user = User.find_by_id(flask.g.user_id)
-        user.upgrade_to_full_account(email, email, password)
+        user.upgrade_to_full_account(email, password=password)
         user.email_verified = True  # Already verified via code
 
         # Clean up codes

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -645,12 +645,12 @@ class User(db.Model):
             f"UPDATE_PASSWORD SUCCESS: user_id={self.id}, email='{self.email}' - Password updated with bcrypt"
         )
 
-    def upgrade_to_full_account(self, email, username, password=None):
+    def upgrade_to_full_account(self, email, name=None, password=None):
         """
         Upgrade an anonymous account to a full account with real email/username.
 
         :param email: Real email address
-        :param username: Display name
+        :param name: Display name
         :param password: Optional new password (keeps existing if not provided)
         :raises ValueError: If user is not anonymous or email is invalid/taken
         """
@@ -672,7 +672,8 @@ class User(db.Model):
         log(f"UPGRADE_ACCOUNT: user_id={self.id} - Upgrading from anonymous to {email}")
 
         self.email = email
-        self.name = username
+        if name:
+         self.name = name
 
         if password:
             self.update_password(password)

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -673,7 +673,7 @@ class User(db.Model):
 
         self.email = email
         if name:
-         self.name = name
+            self.name = name
 
         if password:
             self.update_password(password)


### PR DESCRIPTION
**Problem**
On mobile you always create an anonymous account.

When you have to upgrade you provide
- email
- password

The email was passed in as both email and name resulting in the email beeing showed on frontend after account upgrade

**Solution**
Do not pass email in twice and only set name if a value is provided (aka not None) 