### PR TITLE
Add anonymous account to cohort on account upgrade.

### DIFF
--- a/zeeguu/api/endpoints/accounts.py
+++ b/zeeguu/api/endpoints/accounts.py
@@ -144,10 +144,19 @@ def add_anon_user():
     native_code = request.form.get("native_language_code", None)
     cefr_level = request.form.get("learned_cefr_level", None)
     platform = request.form.get("platform", None)
+    invite_code = request.form.get("invite_code", None)
 
     try:
         generated_username, animal = User.generate_unique_username()
-        new_user = User.create_anonymous(uuid, password, generated_username, language_code, native_code, creation_platform=platform)
+        new_user = User.create_anonymous(
+            uuid,
+            password,
+            generated_username,
+            language_code,
+            native_code,
+            creation_platform=platform,
+            invite_code=invite_code
+         )
         db_session.add(new_user)
         db_session.commit()
 
@@ -189,7 +198,7 @@ def upgrade_anon_user():
         user.upgrade_to_full_account(email, username, password)
         user.email_verified = False  # Requires confirmation
         db_session.commit()
-
+      
         # Send confirmation email
         code = UniqueCode(email)
         db_session.add(code)

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -676,11 +676,10 @@ class User(db.Model):
         if self.invitation_code:
             cohort = Cohort.query.filter(func.lower(Cohort.inv_code) == self.invitation_code.lower()).first()
             if cohort and cohort.cohort_still_has_capacity():
-                self.add_user_to_cohort(cohort.name, db.session)
+                self.add_user_to_cohort(cohort, db.session)
             else:
-                raise Exception(
-                    "No more places in this class. Please contact us (zeeguu.team@gmail.com)."
-                )
+                log(f"UPGRADE_ACCOUNT: user_id={self.id} -The classroom with the invitation code: " +
+                    f"{self.invitation_code} does not exist or does not have enough capacity")
 
         log(f"UPGRADE_ACCOUNT: user_id={self.id} - Upgrading from anonymous to {email}")
 

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -185,6 +185,7 @@ class User(db.Model):
         learned_language_code=None,
         native_language_code=None,
         creation_platform=None,
+        invite_code=None,
     ):
         """
 
@@ -224,6 +225,7 @@ class User(db.Model):
             learned_language=learned_language,
             native_language=native_language,
             creation_platform=creation_platform,
+            invitation_code=invite_code
         )
         new_user.email_verified = False
 
@@ -668,6 +670,17 @@ class User(db.Model):
         # Check email not already taken
         if User.email_exists(email):
             raise ValueError("Email already in use")
+
+        # Add anonymous user to cohort on account upgrade. 
+        from zeeguu.core.model import Cohort
+        if self.invitation_code:
+            cohort = Cohort.query.filter(func.lower(Cohort.inv_code) == self.invitation_code.lower()).first()
+            if cohort and cohort.cohort_still_has_capacity():
+                self.add_user_to_cohort(cohort.name, db.session)
+            else:
+                raise Exception(
+                    "No more places in this class. Please contact us (zeeguu.team@gmail.com)."
+                )
 
         log(f"UPGRADE_ACCOUNT: user_id={self.id} - Upgrading from anonymous to {email}")
 


### PR DESCRIPTION
**Problem**
On mobile when you use an invite code it is not saved on the user account and the user is not added to the cohort/class room.
This is a bad user experience as you have to add the invite code twice.

**Solution**
If you are using an invite code on mobile it is saved on the user.
When you upgrade from the anonymous user to a real user the invite code from the user is used to add the real user to the cohort /classroom. This is the desired behavior.

Note: It does not make sense to add a anonymous user to a classroom and therefore we wait until account upgrade. 