### PR TITLE
Originals-first feed for the on-demand cohort

### DIFF
--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -359,9 +359,38 @@ class UserArticle(db.Model):
         cls, user: User, article: Article
     ) -> Article:
         """
-        Selects the appropriate article version for a user based on their CEFR level.
-        Used for recommendations, search results, and listings.
+        Selects the appropriate article version for a user.
+
+        For users on the new on-demand flow (`always_open_externally`),
+        the feed serves the original (parent) by default. The only time
+        we swap to a simplified version is when the user has previously
+        simplified-and-saved this article — i.e., a PersonalCopy exists
+        on one of the simplified versions. Simplification is no longer
+        pushed onto the feed at crawl time.
+
+        For everyone else, keep the historical behavior: pick the
+        version that matches the user's CEFR level.
         """
+        if user.has_feature("always_open_externally"):
+            from zeeguu.core.model.personal_copy import PersonalCopy
+
+            root = article
+            if article.parent_article_id:
+                parent = Article.query.get(article.parent_article_id)
+                if parent is not None:
+                    root = parent
+
+            saved_simplified = (
+                Article.query
+                .join(PersonalCopy, PersonalCopy.article_id == Article.id)
+                .filter(
+                    PersonalCopy.user_id == user.id,
+                    Article.parent_article_id == root.id,
+                )
+                .first()
+            )
+            return saved_simplified or root
+
         try:
             user_cefr_level = user.cefr_level_for_learned_language()
         except (AttributeError, IndexError, TypeError):
@@ -663,10 +692,18 @@ class UserArticle(db.Model):
                 article = cls.select_appropriate_article_for_user(user, article)
 
                 # Don't show original articles that aren't simplified —
-                # they'd open externally, which defeats the purpose
-                # (legacy users with the feature toggle can still see them)
+                # for default users this would open externally, defeating
+                # the in-reader purpose. Two flags let originals through:
+                # - show_non_simplified_articles: legacy opt-in for users
+                #   who want both originals and simplified in their feed.
+                # - always_open_externally: the new on-demand flow, where
+                #   originals are the feed default and simplified is only
+                #   used for articles the user has personal-copied.
                 if not article.parent_article_id and not article.uploader_id:
-                    if not user.has_feature("show_non_simplified_articles"):
+                    if not (
+                        user.has_feature("show_non_simplified_articles")
+                        or user.has_feature("always_open_externally")
+                    ):
                         continue
 
             if article.id in seen_ids:


### PR DESCRIPTION
## Summary

Users with `always_open_externally` (current new-user default for ids >= 6367 plus the beta allowlist) now see *original* articles in their feed instead of simplified ones. The "Open Externally" button stops being a small contradiction — they were already opening externally, but the feed was still serving the simplified version. With this change the feed and the open behavior agree: the on-demand flow becomes coherent.

## Why

Three things made this the right moment:

- The simplified-only feed has been causing **empty feeds for new users** in low-simplified-content languages (Danish B2 in particular — see project memory). Originals-by-default fixes that immediately.
- `simplify_article` now auto-creates a `PersonalCopy` (shipped earlier today). So a new user reads an original → taps Simplify → next feed load surfaces the simplified version for *that specific article* via the PersonalCopy lookup. The system rewards expressed interest with persistence.
- It aligns with the long-stated direction (on-demand simplification, summarization-only at crawl time).

## Changes

Two small touches in `zeeguu/core/model/user_article.py`:

1. **`select_appropriate_article_for_user`**: when the user has `always_open_externally`, return the parent (or the article itself if it has no parent). If the user has a `PersonalCopy` on a simplified version of the same root, that simplified is returned instead. No CEFR-based swap path runs.
2. **`article_infos` filter**: originals (no `parent_article_id`, no `uploader_id`) now pass through for `always_open_externally` users, alongside the existing `show_non_simplified_articles` legacy opt-in.

No new flag — the cohort that wants the new flow is exactly the cohort already on `always_open_externally`. Adding a parallel flag would have meant carrying two near-identical user lists.

## Cohort impact

- **Default users (no flags)**: unchanged — simplified-first feed.
- **Existing `always_open_externally` users (~30, id 6367-6396)**: feed flips from simplified → originals. They were already opening externally, so the new behavior matches the button. Tapping Simplify on an article saves it and brings the simplified version through on next load.
- **New signups (>= 6397)**: inherit both behaviors coherently.
- **`show_non_simplified_articles` legacy users**: unchanged.

## Test plan

- [ ] As Mircea (id 2319, on the beta allowlist via `always_open_externally`), verify the feed now shows originals.
- [ ] Tap Simplify on an article in the reader → confirm a PersonalCopy is created (already shipped) → return to feed → confirm that *one* article now shows the simplified version with "Open" button (i.e., routed in-reader).
- [ ] As a default user (no flags), verify the feed still shows simplified-first content unchanged.
- [ ] Spot-check Danish B2 feed for an `always_open_externally` user — should now have content where it was empty before.

## Follow-ups (separate PR)

- Consider deprecating crawl-time pre-simplification altogether once this default has been live for a while.
- Possible rename of `always_open_externally` → something broader (it now covers feed-content too), but only after the rollout is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)