### PR TITLE
Match share modal preview + level for extension uploads

### DIFF
--- a/zeeguu/api/endpoints/article_upload.py
+++ b/zeeguu/api/endpoints/article_upload.py
@@ -101,9 +101,23 @@ def article_upload_create():
 @cross_domain
 @requires_session
 def article_upload_get(upload_id):
+    from zeeguu.core.language.cefr_estimator import estimate_cefr_for_text
+
     user = User.find_by_id(flask.g.user_id)
     upload = _find_upload_or_404(upload_id, user)
-    return json_result(upload.as_dictionary())
+    payload = upload.as_dictionary()
+
+    # Mirror /detect_article_info: the share-flow modal renders the level
+    # when present. Estimation is a few-ms ML+FK pass over a 5KB sample.
+    try:
+        lang_code = upload.language.code if upload.language else None
+        payload["cefr_level"] = estimate_cefr_for_text(
+            upload.text_content or upload.raw_html or "", lang_code
+        )
+    except Exception:
+        payload["cefr_level"] = None
+
+    return json_result(payload)
 
 
 @api.route("/article_upload/<int:upload_id>/promote_to_article", methods=["POST"])

--- a/zeeguu/core/model/article_upload.py
+++ b/zeeguu/core/model/article_upload.py
@@ -117,12 +117,15 @@ class ArticleUpload(db.Model):
         return upload
 
     def as_dictionary(self):
+        # Key is `img_url` to match /detect_article_info and the rest of the
+        # web client (article.img_url, ArticlePreview, etc.) — the share-flow
+        # consumer reads the same field regardless of which endpoint fed it.
         return {
             "id": self.id,
             "url": self.url.as_string() if self.url else None,
             "title": self.title,
             "language": self.language.code if self.language else None,
-            "image_url": self.image_url,
+            "img_url": self.image_url,
             "author": self.author,
             "created_at": self.created_at.isoformat() if self.created_at else None,
         }


### PR DESCRIPTION
## Summary
- `/shared-article` accepts both `?url=…` (phone share → `/detect_article_info`) and `?upload_id=…` (extension → `/article_upload/<id>`). The two endpoints returned different shapes, so the upload path silently dropped the modal preview image and CEFR level. This brings the upload response in line with the detect response.
- `ArticleUpload.as_dictionary()`: rename returned key `image_url` → `img_url` to match `/detect_article_info` and the rest of the web client (`article.img_url`, `ArticlePreview`, etc.). The DB column stays `image_url`; only the response key changes.
- `article_upload_get`: estimate `cefr_level` via the existing `estimate_cefr_for_text` helper (same ML+FK pass `/detect_article_info` uses, capped at 5KB of text) and include it in the response. Wrapped in try/except so an estimator failure can't break the share flow.

## Test plan
- [ ] From the extension, "Read with Zeeguu" / popup → `/shared-article?upload_id=…` opens the modal **with** the preview image and CEFR level (parity with phone share).
- [ ] From the phone, share via `?url=…` still works (unchanged path).
- [ ] `/article_upload/<id>` response now contains `img_url` and `cefr_level` fields; `image_url` is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)