### PR TITLE
Removed uuid display name from anonymous account creation

### DIFF
--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -219,7 +219,7 @@ class User(db.Model):
 
         new_user = cls(
             fake_email,
-            uuid,
+            None,
             password,
             username,
             learned_language=learned_language,

--- a/zeeguu/core/test/test_user.py
+++ b/zeeguu/core/test/test_user.py
@@ -36,7 +36,7 @@ class UserTest(ModelTestMixIn):
         )
 
         assert user_to_check.email == str(self.user.id) + User.ANONYMOUS_EMAIL_DOMAIN
-        assert user_to_check.name == str(self.user.id)
+        assert user_to_check.name is None
         assert user_to_check.username == self.user.username
         assert user_to_check.learned_language == self.user.learned_language
         assert user_to_check.native_language == self.user.native_language


### PR DESCRIPTION
Now the anonymous user creation flow does not set the display name to an uuid