### PR TITLE
Fix display names and add avatar color randomization for anonymous accounts

### DIFF
--- a/tools/migrations/26-02-24-b--add_username.py
+++ b/tools/migrations/26-02-24-b--add_username.py
@@ -50,7 +50,7 @@ def _assign(users: list[User], *, prefer_no_digit: bool, assigned_in_session: se
     total = len(users)
     avatar_count = 0
     for i, user in enumerate(users, 1):
-        generated_username, animal = User.generate_unique_username(
+        generated_username, _, animal = User.generate_unique_username(
             exclude=assigned_in_session,
             prefer_no_digit=prefer_no_digit,
         )

--- a/zeeguu/api/endpoints/accounts.py
+++ b/zeeguu/api/endpoints/accounts.py
@@ -160,7 +160,8 @@ def add_anon_user():
         db_session.add(new_user)
         db_session.commit()
 
-        user_avatar = UserAvatar(new_user.id, animal, None, None)
+        character_color, background_color = UserAvatar.random_colors()
+        user_avatar = UserAvatar(new_user.id, animal, character_color, background_color)
         db_session.add(user_avatar)
         db_session.commit()
 

--- a/zeeguu/api/endpoints/accounts.py
+++ b/zeeguu/api/endpoints/accounts.py
@@ -147,13 +147,15 @@ def add_anon_user():
     invite_code = request.form.get("invite_code", None)
 
     try:
-        generated_username, animal = User.generate_unique_username()
+        generated_username, adjective, animal = User.generate_unique_username()
+        generated_display_name = f"{adjective.capitalize()} {animal.capitalize()}"
         new_user = User.create_anonymous(
             uuid,
             password,
             generated_username,
-            language_code,
-            native_code,
+            name=generated_display_name,
+            learned_language_code=language_code,
+            native_language_code=native_code,
             creation_platform=platform,
             invite_code=invite_code
          )

--- a/zeeguu/core/account_management/user_account_creation.py
+++ b/zeeguu/core/account_management/user_account_creation.py
@@ -138,7 +138,7 @@ def create_account(
         native_language = Language.find_or_create(native_language_code)
 
         def build_user():
-            generated_username, animal = User.generate_unique_username()
+            generated_username, _, animal = User.generate_unique_username()
             user = User(
                 email,
                 username,
@@ -220,7 +220,7 @@ def create_basic_account(
             )
     try:
         def build_user():
-            generated_username, animal = User.generate_unique_username()
+            generated_username, _, animal = User.generate_unique_username()
             user = User(
                 email,
                 username,

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -147,8 +147,9 @@ class User(db.Model):
             prefer_no_digit: start at tier 0 (default) or skip to tier 4.
 
         Returns:
-            (username, animal) tuple. The animal is returned separately so
-            callers can pick the matching avatar SVG.
+            (username, adjective, animal) tuple where adjective/animal are the
+            selected words used to build the username. Callers can use these
+            to derive a display name and choose a matching avatar.
         """
         exclude = exclude or set()
         tiers = cls._USERNAME_TIERS_PRETTY if prefer_no_digit else cls._USERNAME_TIERS_FALLBACK
@@ -170,7 +171,7 @@ class User(db.Model):
                 if username in exclude:
                     continue
                 if not cls.query.filter_by(username=username).first():
-                    return username, animal
+                    return username, adjective, animal
 
         raise RuntimeError(
             "Username space exhausted across all tiers — expand ADJECTIVES/ANIMALS."
@@ -182,6 +183,7 @@ class User(db.Model):
         uuid,
         password,
         username,
+        name=None,
         learned_language_code=None,
         native_language_code=None,
         creation_platform=None,
@@ -192,6 +194,7 @@ class User(db.Model):
         :param uuid:
         :param password:
         :param username:
+        :param name:
         :param learned_language_code:
         :param native_language_code:
         :param creation_platform:
@@ -219,7 +222,7 @@ class User(db.Model):
 
         new_user = cls(
             fake_email,
-            None,
+            name,
             password,
             username,
             learned_language=learned_language,

--- a/zeeguu/core/test/test_user.py
+++ b/zeeguu/core/test/test_user.py
@@ -31,8 +31,8 @@ class UserTest(ModelTestMixIn):
             str(self.user.id),
             new_password,
             self.user.username,
-            self.user.learned_language.code,
-            self.user.native_language.code,
+            learned_language_code=self.user.learned_language.code,
+            native_language_code=self.user.native_language.code,
         )
 
         assert user_to_check.email == str(self.user.id) + User.ANONYMOUS_EMAIL_DOMAIN


### PR DESCRIPTION
The PR contains two fixes:
1. Anonymous account display names are now derived from the generated usernames. See related issue explained in https://github.com/zeeguu/web/issues/1095. This PR contains the proposed fix.
2. During normal registration, accounts get randomized avatar colors. Anonymous account creation was missing the color randomization, now it's consistent.