### PR TITLE
Add shared_audio_lesson endpoint for share-link consumption

### DIFF
--- a/zeeguu/api/endpoints/audio_lessons.py
+++ b/zeeguu/api/endpoints/audio_lessons.py
@@ -159,6 +159,21 @@ def get_daily_lesson():
     return json_result(result), status_code
 
 
+@api.route("/shared_audio_lesson/<int:lesson_id>", methods=["GET"])
+@cross_domain
+def get_shared_audio_lesson(lesson_id):
+    """
+    Read-only public view of an audio lesson for share links. Returns the
+    lesson metadata + audio URL, but no owner-specific state (pause position,
+    completion, listen count) and no UserWord data. No session required —
+    matches the static audio file's accessibility.
+    """
+    generator = DailyLessonGenerator()
+    result = generator.get_shared_lesson_view(lesson_id)
+    status_code = result.pop("status_code", 200)
+    return json_result(result), status_code
+
+
 @api.route("/get_todays_lesson", methods=["GET"])
 @cross_domain
 @requires_session

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -598,6 +598,55 @@ class DailyLessonGenerator:
             "listened_count": lesson.listened_count,
             "canonical_suggestion": lesson.canonical_suggestion,
             "lesson_type": lesson.lesson_type,
+            "language_code": lesson.language.code if lesson.language else None,
+        }
+        if dialogue_title:
+            result["title"] = dialogue_title
+        return result
+
+    def get_shared_lesson_view(self, lesson_id):
+        """
+        Public-safe view of a lesson for share links: no per-user playback
+        state (pause position, completion, listen count) and no UserWord data.
+        Anyone with the lesson id can read this; tracking happens elsewhere
+        only for the owner's own playback.
+        """
+        try:
+            lesson_id = int(lesson_id)
+        except (TypeError, ValueError):
+            return {"error": "Invalid lesson_id parameter", "status_code": 400}
+
+        lesson = DailyAudioLesson.query.filter_by(id=lesson_id).first()
+        if not lesson:
+            return {"error": "Lesson not found", "status_code": 404}
+
+        audio_path = os.path.join(
+            ZEEGUU_DATA_FOLDER, "audio", "daily_lessons", f"{lesson.id}.mp3"
+        )
+        if not os.path.exists(audio_path):
+            return {"error": "Audio file not found for this lesson", "status_code": 404}
+
+        words = []
+        dialogue_title = None
+        for segment in lesson.segments:
+            if segment.segment_type == "meaning_lesson" and segment.audio_lesson_meaning:
+                meaning = segment.audio_lesson_meaning.meaning
+                words.append({
+                    "origin": meaning.origin.content,
+                    "translation": meaning.translation.content,
+                })
+            elif segment.segment_type == "dialogue_lesson" and segment.audio_lesson_dialogue:
+                dialogue_title = segment.audio_lesson_dialogue.title
+
+        result = {
+            "lesson_id": lesson.id,
+            "audio_url": f"/audio/daily_lessons/{lesson.id}.mp3",
+            "duration_seconds": lesson.duration_seconds,
+            "created_at": lesson.created_at.isoformat() if lesson.created_at else None,
+            "words": words,
+            "canonical_suggestion": lesson.canonical_suggestion,
+            "lesson_type": lesson.lesson_type,
+            "language_code": lesson.language.code if lesson.language else None,
         }
         if dialogue_title:
             result["title"] = dialogue_title

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -545,46 +545,49 @@ class DailyLessonGenerator:
 
         return start_of_today_utc, end_of_today_utc
 
-    def _format_lesson_response(self, lesson):
-        """Format a lesson into the standard response format."""
-        from zeeguu.core.model import UserWord
-
-        # Check if audio file exists
-        audio_path = os.path.join(
+    def _audio_path(self, lesson):
+        return os.path.join(
             ZEEGUU_DATA_FOLDER, "audio", "daily_lessons", f"{lesson.id}.mp3"
         )
 
-        if not os.path.exists(audio_path):
-            return {"error": "Audio file not found for this lesson", "status_code": 404}
+    def _extract_segments(self, lesson, *, with_user_metadata):
+        """Walk lesson.segments and return (words, dialogue_title).
 
-        # Get lesson details including words with full metadata
+        with_user_metadata=True attaches the owner's UserWord state
+        (used by the owner's own playback view); False returns just
+        origin/translation strings (used by shared/public views).
+        """
+        from zeeguu.core.model import UserWord
+
         words = []
         dialogue_title = None
         for segment in lesson.segments:
-            if (
-                segment.segment_type == "meaning_lesson"
-                and segment.audio_lesson_meaning
-            ):
+            if segment.segment_type == "meaning_lesson" and segment.audio_lesson_meaning:
                 meaning = segment.audio_lesson_meaning.meaning
-                user_word = UserWord.query.filter_by(
-                    user_id=lesson.user_id,
-                    meaning_id=meaning.id
-                ).first()
-
+                user_word = (
+                    UserWord.query.filter_by(
+                        user_id=lesson.user_id, meaning_id=meaning.id
+                    ).first()
+                    if with_user_metadata
+                    else None
+                )
                 if user_word:
                     words.append(user_word.as_dictionary())
                 else:
-                    words.append(
-                        {
-                            "origin": meaning.origin.content,
-                            "translation": meaning.translation.content,
-                        }
-                    )
-            elif (
-                segment.segment_type == "dialogue_lesson"
-                and segment.audio_lesson_dialogue
-            ):
+                    words.append({
+                        "origin": meaning.origin.content,
+                        "translation": meaning.translation.content,
+                    })
+            elif segment.segment_type == "dialogue_lesson" and segment.audio_lesson_dialogue:
                 dialogue_title = segment.audio_lesson_dialogue.title
+        return words, dialogue_title
+
+    def _format_lesson_response(self, lesson):
+        """Format a lesson into the standard (owner) response format."""
+        if not os.path.exists(self._audio_path(lesson)):
+            return {"error": "Audio file not found for this lesson", "status_code": 404}
+
+        words, dialogue_title = self._extract_segments(lesson, with_user_metadata=True)
 
         result = {
             "lesson_id": lesson.id,
@@ -605,12 +608,7 @@ class DailyLessonGenerator:
         return result
 
     def get_shared_lesson_view(self, lesson_id):
-        """
-        Public-safe view of a lesson for share links: no per-user playback
-        state (pause position, completion, listen count) and no UserWord data.
-        Anyone with the lesson id can read this; tracking happens elsewhere
-        only for the owner's own playback.
-        """
+        """Public-safe view for share links: no owner playback state, no UserWord rows."""
         try:
             lesson_id = int(lesson_id)
         except (TypeError, ValueError):
@@ -619,24 +617,10 @@ class DailyLessonGenerator:
         lesson = DailyAudioLesson.query.filter_by(id=lesson_id).first()
         if not lesson:
             return {"error": "Lesson not found", "status_code": 404}
-
-        audio_path = os.path.join(
-            ZEEGUU_DATA_FOLDER, "audio", "daily_lessons", f"{lesson.id}.mp3"
-        )
-        if not os.path.exists(audio_path):
+        if not os.path.exists(self._audio_path(lesson)):
             return {"error": "Audio file not found for this lesson", "status_code": 404}
 
-        words = []
-        dialogue_title = None
-        for segment in lesson.segments:
-            if segment.segment_type == "meaning_lesson" and segment.audio_lesson_meaning:
-                meaning = segment.audio_lesson_meaning.meaning
-                words.append({
-                    "origin": meaning.origin.content,
-                    "translation": meaning.translation.content,
-                })
-            elif segment.segment_type == "dialogue_lesson" and segment.audio_lesson_dialogue:
-                dialogue_title = segment.audio_lesson_dialogue.title
+        words, dialogue_title = self._extract_segments(lesson, with_user_metadata=False)
 
         result = {
             "lesson_id": lesson.id,

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -550,8 +550,8 @@ class DailyLessonGenerator:
             ZEEGUU_DATA_FOLDER, "audio", "daily_lessons", f"{lesson.id}.mp3"
         )
 
-    def _extract_segments(self, lesson, *, with_user_metadata):
-        """Walk lesson.segments and return (words, dialogue_title).
+    def _extract_segment_words(self, lesson, *, with_user_metadata):
+        """Words list from meaning_lesson segments.
 
         with_user_metadata=True attaches the owner's UserWord state
         (used by the owner's own playback view); False returns just
@@ -560,41 +560,44 @@ class DailyLessonGenerator:
         from zeeguu.core.model import UserWord
 
         words = []
-        dialogue_title = None
         for segment in lesson.segments:
-            if segment.segment_type == "meaning_lesson" and segment.audio_lesson_meaning:
-                meaning = segment.audio_lesson_meaning.meaning
-                user_word = (
-                    UserWord.query.filter_by(
-                        user_id=lesson.user_id, meaning_id=meaning.id
-                    ).first()
-                    if with_user_metadata
-                    else None
-                )
-                if user_word:
-                    words.append(user_word.as_dictionary())
-                else:
-                    words.append({
-                        "origin": meaning.origin.content,
-                        "translation": meaning.translation.content,
-                    })
-            elif segment.segment_type == "dialogue_lesson" and segment.audio_lesson_dialogue:
-                dialogue_title = segment.audio_lesson_dialogue.title
-        return words, dialogue_title
+            if not (segment.segment_type == "meaning_lesson" and segment.audio_lesson_meaning):
+                continue
+            meaning = segment.audio_lesson_meaning.meaning
+            user_word = (
+                UserWord.query.filter_by(
+                    user_id=lesson.user_id, meaning_id=meaning.id
+                ).first()
+                if with_user_metadata
+                else None
+            )
+            if user_word:
+                words.append(user_word.as_dictionary())
+            else:
+                words.append({
+                    "origin": meaning.origin.content,
+                    "translation": meaning.translation.content,
+                })
+        return words
+
+    def _dialogue_lesson_title(self, lesson):
+        """Title of the dialogue segment if the lesson has one, else None."""
+        for segment in lesson.segments:
+            if segment.segment_type == "dialogue_lesson" and segment.audio_lesson_dialogue:
+                return segment.audio_lesson_dialogue.title
+        return None
 
     def _format_lesson_response(self, lesson):
         """Format a lesson into the standard (owner) response format."""
         if not os.path.exists(self._audio_path(lesson)):
             return {"error": "Audio file not found for this lesson", "status_code": 404}
 
-        words, dialogue_title = self._extract_segments(lesson, with_user_metadata=True)
-
         result = {
             "lesson_id": lesson.id,
             "audio_url": f"/audio/daily_lessons/{lesson.id}.mp3",
             "duration_seconds": lesson.duration_seconds,
             "created_at": lesson.created_at.isoformat() if lesson.created_at else None,
-            "words": words,
+            "words": self._extract_segment_words(lesson, with_user_metadata=True),
             "pause_position_seconds": lesson.pause_position_seconds,
             "is_paused": lesson.is_paused,
             "is_completed": lesson.is_completed,
@@ -603,8 +606,9 @@ class DailyLessonGenerator:
             "lesson_type": lesson.lesson_type,
             "language_code": lesson.language.code if lesson.language else None,
         }
-        if dialogue_title:
-            result["title"] = dialogue_title
+        lesson_title = self._dialogue_lesson_title(lesson)
+        if lesson_title:
+            result["title"] = lesson_title
         return result
 
     def get_shared_lesson_view(self, lesson_id):
@@ -620,20 +624,19 @@ class DailyLessonGenerator:
         if not os.path.exists(self._audio_path(lesson)):
             return {"error": "Audio file not found for this lesson", "status_code": 404}
 
-        words, dialogue_title = self._extract_segments(lesson, with_user_metadata=False)
-
         result = {
             "lesson_id": lesson.id,
             "audio_url": f"/audio/daily_lessons/{lesson.id}.mp3",
             "duration_seconds": lesson.duration_seconds,
             "created_at": lesson.created_at.isoformat() if lesson.created_at else None,
-            "words": words,
+            "words": self._extract_segment_words(lesson, with_user_metadata=False),
             "canonical_suggestion": lesson.canonical_suggestion,
             "lesson_type": lesson.lesson_type,
             "language_code": lesson.language.code if lesson.language else None,
         }
-        if dialogue_title:
-            result["title"] = dialogue_title
+        lesson_title = self._dialogue_lesson_title(lesson)
+        if lesson_title:
+            result["title"] = lesson_title
         return result
 
     def get_daily_lesson_for_user(self, user, lesson_id=None):


### PR DESCRIPTION
## Summary

- New endpoint `GET /shared_audio_lesson/<id>` returns a public-safe view of a daily audio lesson for share-link recipients. No `@requires_session` — matches the static audio file's accessibility. Response excludes per-user state (`pause_position_seconds`, `is_completed`, `listened_count`) and UserWord data; recipients only see what they need to play and identify the lesson.
- Adds `language_code` to the existing lesson response so the frontend share-link page can decide whether the recipient learns the lesson's language and pick the appropriate banner.

## Why this shape

The frontend pair PR adds a `/shared-lesson/:id` route. Recipients fetching their own copy through the existing `get_daily_lesson` endpoint would be blocked by its `user_id=user.id` filter, and even if we relaxed that, the existing path returns the owner's playback state. A separate read-only endpoint with a slim payload was simpler than threading a `preview` flag through the original.

## Frontend pair

zeeguu/web#1099 — adds the Share button, the share-link page, and the iOS/Android deep-link path entries.

## Test plan

- [ ] `GET /shared_audio_lesson/<id>` for a real lesson returns 200 with `audio_url`, `language_code`, `title`/`canonical_suggestion`, words (origin/translation only).
- [ ] `GET /shared_audio_lesson/<bogus_id>` returns 404 with `error`.
- [ ] `GET /shared_audio_lesson/abc` returns 400 with `error`.
- [ ] No session cookie required.
- [ ] Existing `get_daily_lesson` / `get_todays_lesson` still return their full payload + new `language_code` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)