### PR TITLE
Include lesson title + id in audio activity sessions

### DIFF
--- a/zeeguu/api/endpoints/session_history.py
+++ b/zeeguu/api/endpoints/session_history.py
@@ -80,28 +80,6 @@ def _words_for_audio_lesson(audio_lesson, language_id=None):
     return result
 
 
-def _audio_lesson_title(audio_lesson):
-    """
-    Best-effort title for an audio lesson, suitable for activity-history rows.
-
-    Picks the first available source: dialogue title → "Topic/Situation: X"
-    from canonical_suggestion → comma-joined word origins. Returns None for
-    a lesson with no segments at all (shouldn't happen but defensive).
-    """
-    if not audio_lesson:
-        return None
-    for segment in audio_lesson.segments:
-        if segment.segment_type == "dialogue_lesson" and segment.audio_lesson_dialogue:
-            return segment.audio_lesson_dialogue.title
-    if audio_lesson.canonical_suggestion:
-        prefix = "Situation" if audio_lesson.lesson_type == "situation" else "Topic"
-        return f"{prefix}: {audio_lesson.canonical_suggestion}"
-    origins = [
-        segment.audio_lesson_meaning.meaning.origin.content
-        for segment in audio_lesson.segments
-        if segment.segment_type == "meaning_lesson" and segment.audio_lesson_meaning
-    ]
-    return ", ".join(origins) if origins else None
 
 
 def _exercises_for_session(session_id, language_id=None):
@@ -353,7 +331,7 @@ def session_history():
                 "word_count": len(words),
                 "completed": is_completed,
                 "lesson_id": audio_lesson.id if audio_lesson else None,
-                "lesson_title": _audio_lesson_title(audio_lesson),
+                "lesson_title": audio_lesson.display_title() if audio_lesson else None,
             }
         )
 

--- a/zeeguu/api/endpoints/session_history.py
+++ b/zeeguu/api/endpoints/session_history.py
@@ -80,6 +80,30 @@ def _words_for_audio_lesson(audio_lesson, language_id=None):
     return result
 
 
+def _audio_lesson_title(audio_lesson):
+    """
+    Best-effort title for an audio lesson, suitable for activity-history rows.
+
+    Picks the first available source: dialogue title → "Topic/Situation: X"
+    from canonical_suggestion → comma-joined word origins. Returns None for
+    a lesson with no segments at all (shouldn't happen but defensive).
+    """
+    if not audio_lesson:
+        return None
+    for segment in audio_lesson.segments:
+        if segment.segment_type == "dialogue_lesson" and segment.audio_lesson_dialogue:
+            return segment.audio_lesson_dialogue.title
+    if audio_lesson.canonical_suggestion:
+        prefix = "Situation" if audio_lesson.lesson_type == "situation" else "Topic"
+        return f"{prefix}: {audio_lesson.canonical_suggestion}"
+    origins = [
+        segment.audio_lesson_meaning.meaning.origin.content
+        for segment in audio_lesson.segments
+        if segment.segment_type == "meaning_lesson" and segment.audio_lesson_meaning
+    ]
+    return ", ".join(origins) if origins else None
+
+
 def _exercises_for_session(session_id, language_id=None):
     """Get exercise summary for an exercise session."""
     exercises = (
@@ -328,6 +352,8 @@ def session_history():
                 "words": words,
                 "word_count": len(words),
                 "completed": is_completed,
+                "lesson_id": audio_lesson.id if audio_lesson else None,
+                "lesson_title": _audio_lesson_title(audio_lesson),
             }
         )
 

--- a/zeeguu/core/model/daily_audio_lesson.py
+++ b/zeeguu/core/model/daily_audio_lesson.py
@@ -165,6 +165,29 @@ class DailyAudioLesson(db.Model):
         """Check if lesson is currently paused"""
         return self.pause_position_seconds > 0 and not self.is_completed
 
+    def display_title(self):
+        """
+        Best-effort human-readable title for this lesson.
+
+        Single source of truth used by every response that needs a label —
+        regular lesson endpoints, the shared-link endpoint, and activity
+        history rows. Picks the first available source: dialogue title →
+        "Topic/Situation: X" from canonical_suggestion → comma-joined
+        word origins. Returns None for a lesson with no segments.
+        """
+        for segment in self.segments:
+            if segment.segment_type == "dialogue_lesson" and segment.audio_lesson_dialogue:
+                return segment.audio_lesson_dialogue.title
+        if self.canonical_suggestion:
+            prefix = "Situation" if self.lesson_type == "situation" else "Topic"
+            return f"{prefix}: {self.canonical_suggestion}"
+        origins = [
+            segment.audio_lesson_meaning.meaning.origin.content
+            for segment in self.segments
+            if segment.segment_type == "meaning_lesson" and segment.audio_lesson_meaning
+        ]
+        return ", ".join(origins) if origins else None
+
     @classmethod
     def find_canonical_for_raw_suggestion(cls, user, raw_suggestion):
         """Find the canonical form previously used for this raw suggestion by this user."""


### PR DESCRIPTION
## Summary

Audio (listening) sessions in `/session_history` previously returned `session_type, start_time, duration, words, word_count, completed` — no title, no lesson reference. Reading sessions next to them have always returned `article_title` and `article_id`. This PR brings audio rows to parity by adding `lesson_title` and `lesson_id`.

`lesson_title` is computed as the first available of:
1. Dialogue segment's `title` (for dialogue lessons)
2. `"Topic: X"` / `"Situation: X"` from `canonical_suggestion`
3. Comma-joined word origins (e.g. "kennen, dachte, glaubte")

## Frontend pair

zeeguu/web#1100 — renders the title under the audio session card header.

## Test plan

- [ ] Activity history shows a recognizable title for audio rows (dialogue, topic, and word-list lessons all sensible).
- [ ] Existing reading/exercise/browsing rows unaffected.
- [ ] No new queries — title is computed from already-loaded `audio_lesson.segments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)