### PR TITLE
Single source of truth for lesson display title

### DIFF
--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -580,19 +580,12 @@ class DailyLessonGenerator:
                 })
         return words
 
-    def _dialogue_lesson_title(self, lesson):
-        """Title of the dialogue segment if the lesson has one, else None."""
-        for segment in lesson.segments:
-            if segment.segment_type == "dialogue_lesson" and segment.audio_lesson_dialogue:
-                return segment.audio_lesson_dialogue.title
-        return None
-
     def _format_lesson_response(self, lesson):
         """Format a lesson into the standard (owner) response format."""
         if not os.path.exists(self._audio_path(lesson)):
             return {"error": "Audio file not found for this lesson", "status_code": 404}
 
-        result = {
+        return {
             "lesson_id": lesson.id,
             "audio_url": f"/audio/daily_lessons/{lesson.id}.mp3",
             "duration_seconds": lesson.duration_seconds,
@@ -605,11 +598,8 @@ class DailyLessonGenerator:
             "canonical_suggestion": lesson.canonical_suggestion,
             "lesson_type": lesson.lesson_type,
             "language_code": lesson.language.code if lesson.language else None,
+            "title": lesson.display_title(),
         }
-        lesson_title = self._dialogue_lesson_title(lesson)
-        if lesson_title:
-            result["title"] = lesson_title
-        return result
 
     def get_shared_lesson_view(self, lesson_id):
         """Public-safe view for share links: no owner playback state, no UserWord rows."""
@@ -624,7 +614,7 @@ class DailyLessonGenerator:
         if not os.path.exists(self._audio_path(lesson)):
             return {"error": "Audio file not found for this lesson", "status_code": 404}
 
-        result = {
+        return {
             "lesson_id": lesson.id,
             "audio_url": f"/audio/daily_lessons/{lesson.id}.mp3",
             "duration_seconds": lesson.duration_seconds,
@@ -633,11 +623,8 @@ class DailyLessonGenerator:
             "canonical_suggestion": lesson.canonical_suggestion,
             "lesson_type": lesson.lesson_type,
             "language_code": lesson.language.code if lesson.language else None,
+            "title": lesson.display_title(),
         }
-        lesson_title = self._dialogue_lesson_title(lesson)
-        if lesson_title:
-            result["title"] = lesson_title
-        return result
 
     def get_daily_lesson_for_user(self, user, lesson_id=None):
         """

--- a/zeeguu/core/model/daily_audio_lesson.py
+++ b/zeeguu/core/model/daily_audio_lesson.py
@@ -165,6 +165,29 @@ class DailyAudioLesson(db.Model):
         """Check if lesson is currently paused"""
         return self.pause_position_seconds > 0 and not self.is_completed
 
+    def display_title(self):
+        """
+        Best-effort human-readable title for this lesson.
+
+        Single source of truth used by every response that needs a label —
+        regular lesson endpoints, the shared-link endpoint, and activity
+        history rows. Picks the first available source: dialogue title →
+        "Topic/Situation: X" from canonical_suggestion → comma-joined
+        word origins. Returns None for a lesson with no segments.
+        """
+        for segment in self.segments:
+            if segment.segment_type == "dialogue_lesson" and segment.audio_lesson_dialogue:
+                return segment.audio_lesson_dialogue.title
+        if self.canonical_suggestion:
+            prefix = "Situation" if self.lesson_type == "situation" else "Topic"
+            return f"{prefix}: {self.canonical_suggestion}"
+        origins = [
+            segment.audio_lesson_meaning.meaning.origin.content
+            for segment in self.segments
+            if segment.segment_type == "meaning_lesson" and segment.audio_lesson_meaning
+        ]
+        return ", ".join(origins) if origins else None
+
     @classmethod
     def find_canonical_for_raw_suggestion(cls, user, raw_suggestion):
         """Find the canonical form previously used for this raw suggestion by this user."""


### PR DESCRIPTION
## Summary

Adds `DailyAudioLesson.display_title()` as the single place that computes a lesson's display label. Both `_format_lesson_response` (regular endpoint) and `get_shared_lesson_view` (share-link endpoint) now always include a `title` field in their response, computed via this one method.

This was previously inconsistent: `_format_lesson_response` only set `title` for dialogue lessons, leaving the frontend to fall back to `wordsAsTile(words)`. That fallback duplicated the backend's logic and meant the same lesson could render with different titles depending on which code path produced it.

`display_title()` picks the first available source:
1. Dialogue segment's `title`
2. `"Topic: X"` / `"Situation: X"` from `canonical_suggestion`
3. Comma-joined word origins (e.g. "kennen, dachte, glaubte")

## Frontend pair

zeeguu/web#1099 — drops the `wordsAsTile` fallback in `SharedLessonView` and `LessonPlaybackView`; both views just render `lessonData.title` now.

## Related

zeeguu/api#596 (`fix/audio-session-title-in-activity`) adds the same `display_title()` method to the model so `session_history.py` can use it for activity-history rows. When both PRs land, expect a trivial conflict in `daily_audio_lesson.py` from the duplicate identical addition.

## Test plan

- [ ] `/get_daily_lesson`, `/get_todays_lesson`, `/shared_audio_lesson/<id>` all return a non-null `title` for dialogue, topic, situation, and word-list lessons.
- [ ] Regression: existing frontend pages (today's audio, past lessons) still render the title correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)