### PR TITLE
Fix: issue 592 case sensitive email (with migration)

### DIFF
--- a/tools/migrations/26-05-06--update_email_in_unique_code.sql
+++ b/tools/migrations/26-05-06--update_email_in_unique_code.sql
@@ -1,0 +1,4 @@
+-- Before this migration the email in 'unique_code' was case sensitive
+-- This migration updates the collation for the email to utf8mb4_unicode_ci 
+ALTER TABLE unique_code MODIFY email VARCHAR(255) 
+CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
## Problem
On the frontend the email verification fails in the upgrade account modal if the email is not lower cased.
#592 

## Testing
- [x] Test frontend locally