### PR TITLE
Sticky completion for DailyAudioLesson; rename completed_at -> last_completed_at

### DIFF
--- a/tools/migrations/26-05-10--rename_daily_audio_completed_at.sql
+++ b/tools/migrations/26-05-10--rename_daily_audio_completed_at.sql
@@ -1,0 +1,7 @@
+-- Rename DailyAudioLesson.completed_at to last_completed_at.
+-- Completion is sticky (a historical fact); replaying a completed lesson
+-- no longer clears it. Naming makes that explicit: this is the timestamp
+-- of the most recent completion, never reset to NULL once set.
+
+ALTER TABLE daily_audio_lesson
+  CHANGE COLUMN completed_at last_completed_at TIMESTAMP NULL;

--- a/zeeguu/api/endpoints/user_stats.py
+++ b/zeeguu/api/endpoints/user_stats.py
@@ -245,8 +245,8 @@ def get_audio_lesson_stats_for_user(user_id, start, end):
     # Get lessons completed in this period
     lessons = (
         DailyAudioLesson.query.filter(DailyAudioLesson.user_id == user_id)
-        .filter(DailyAudioLesson.completed_at >= start)
-        .filter(DailyAudioLesson.completed_at < end)
+        .filter(DailyAudioLesson.last_completed_at >= start)
+        .filter(DailyAudioLesson.last_completed_at < end)
         .all()
     )
 
@@ -308,8 +308,8 @@ def collect_user_activity(start, end):
     # Find all users with completed audio lessons in this period
     audio_lesson_user_ids = (
         db_session.query(DailyAudioLesson.user_id)
-        .filter(DailyAudioLesson.completed_at >= start)
-        .filter(DailyAudioLesson.completed_at < end)
+        .filter(DailyAudioLesson.last_completed_at >= start)
+        .filter(DailyAudioLesson.last_completed_at < end)
         .distinct()
         .all()
     )
@@ -942,9 +942,9 @@ def user_stats_individual_dashboard(user_id):
     # Get audio lessons
     audio_lessons = (
         DailyAudioLesson.query.filter(DailyAudioLesson.user_id == user_id)
-        .filter(DailyAudioLesson.completed_at >= start)
-        .filter(DailyAudioLesson.completed_at < end)
-        .order_by(DailyAudioLesson.completed_at.desc())
+        .filter(DailyAudioLesson.last_completed_at >= start)
+        .filter(DailyAudioLesson.last_completed_at < end)
+        .order_by(DailyAudioLesson.last_completed_at.desc())
         .all()
     )
 
@@ -1194,7 +1194,7 @@ def user_stats_individual_dashboard(user_id):
             duration_min = (lesson.duration_seconds or 0) / 60
             lesson_lang = lesson.language.code.upper() if lesson.language else "?"
             completed_time = (
-                lesson.completed_at.strftime("%H:%M") if lesson.completed_at else "?"
+                lesson.last_completed_at.strftime("%H:%M") if lesson.last_completed_at else "?"
             )
 
             html += f"""
@@ -1842,8 +1842,8 @@ def _compute_active_users_for_month(month_start, month_end):
 
     audio_users = (
         db_session.query(distinct(DailyAudioLesson.user_id))
-        .filter(DailyAudioLesson.completed_at >= month_start)
-        .filter(DailyAudioLesson.completed_at < month_end)
+        .filter(DailyAudioLesson.last_completed_at >= month_start)
+        .filter(DailyAudioLesson.last_completed_at < month_end)
     )
 
     bookmark_users = (
@@ -2271,8 +2271,8 @@ def _compute_activity_stats_for_month(month_start, month_end):
     # Audio minutes (stored in seconds)
     audio_sec = (
         db_session.query(func.sum(DailyAudioLesson.duration_seconds))
-        .filter(DailyAudioLesson.completed_at >= month_start)
-        .filter(DailyAudioLesson.completed_at < month_end)
+        .filter(DailyAudioLesson.last_completed_at >= month_start)
+        .filter(DailyAudioLesson.last_completed_at < month_end)
         .scalar()
     ) or 0
 

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -833,9 +833,9 @@ class DailyLessonGenerator:
                         "created_at": (
                             lesson.created_at.isoformat() if lesson.created_at else None
                         ),
-                        "completed_at": (
-                            lesson.completed_at.isoformat()
-                            if lesson.completed_at
+                        "last_completed_at": (
+                            lesson.last_completed_at.isoformat()
+                            if lesson.last_completed_at
                             else None
                         ),
                         "is_completed": lesson.is_completed,
@@ -897,16 +897,12 @@ class DailyLessonGenerator:
                 lesson.pause_at(position_seconds)
 
             elif action == "resume":
-                # Resume from pause or start new play
-
-                # Check if this is a replay from the beginning
-                # If already listened and starting from beginning, it's a new listen
+                # Resume from pause or start a new play. Completion is sticky
+                # — replaying a completed lesson does NOT clear last_completed_at,
+                # only bumps the listen counter so we can show how many times
+                # the user has come back to it.
                 if lesson.pause_position_seconds < 1:
-                    # Starting a new play from beginning - increment counter
                     lesson.listened_count += 1
-                    # Clear completion status if it was completed
-                    if lesson.is_completed:
-                        lesson.completed_at = None
 
                 lesson.resume()
 
@@ -1039,7 +1035,7 @@ User: {user.name} ({user.email})
 User ID: {user.id}
 Lesson ID: {lesson.id}
 Language: {lesson.language.name}
-Completion Time: {lesson.completed_at.strftime('%Y-%m-%d %H:%M:%S') if lesson.completed_at else 'Unknown'}
+Completion Time: {lesson.last_completed_at.strftime('%Y-%m-%d %H:%M:%S') if lesson.last_completed_at else 'Unknown'}
 Duration: {lesson.duration_seconds}s
 Words Practiced: {len(lesson_words)}
 

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -904,8 +904,6 @@ class DailyLessonGenerator:
                 if lesson.pause_position_seconds < 1:
                     lesson.listened_count += 1
 
-                lesson.resume()
-
             elif action == "complete":
                 # Mark lesson as completed
                 lesson.mark_completed()

--- a/zeeguu/core/model/daily_audio_lesson.py
+++ b/zeeguu/core/model/daily_audio_lesson.py
@@ -33,7 +33,7 @@ class DailyAudioLesson(db.Model):
 
     # User interaction tracking
     recommended_at = Column(TIMESTAMP, default=datetime.utcnow)
-    completed_at = Column(TIMESTAMP)
+    last_completed_at = Column(TIMESTAMP)
     listened_count = Column(Integer, default=0)
 
     # Pause/resume tracking
@@ -133,8 +133,8 @@ class DailyAudioLesson(db.Model):
         return sum(1 for s in self.segments if s.segment_type == "meaning_lesson")
 
     def mark_completed(self):
-        """Mark this lesson as completed"""
-        self.completed_at = datetime.utcnow()
+        """Mark this lesson as completed (sets/updates last_completed_at)."""
+        self.last_completed_at = datetime.utcnow()
         # Only count as a listen if it hasn't been counted yet
         if self.listened_count == 0:
             self.listened_count = 1
@@ -157,8 +157,8 @@ class DailyAudioLesson(db.Model):
 
     @property
     def is_completed(self):
-        """Check if lesson has been completed"""
-        return self.completed_at is not None
+        """Check if lesson has been completed (sticky once true)."""
+        return self.last_completed_at is not None
 
     @property
     def is_paused(self):
@@ -204,6 +204,6 @@ class DailyAudioLesson(db.Model):
         """Find the most recent audio lesson for a user"""
         query = cls.query.filter_by(user=user)
         if not include_completed:
-            query = query.filter(cls.completed_at.is_(None))
+            query = query.filter(cls.last_completed_at.is_(None))
         return query.order_by(cls.recommended_at.desc()).first()
 

--- a/zeeguu/core/model/daily_audio_lesson.py
+++ b/zeeguu/core/model/daily_audio_lesson.py
@@ -149,12 +149,6 @@ class DailyAudioLesson(db.Model):
         else:
             self.pause_position_seconds = position_seconds
 
-    def resume(self):
-        """Clear pause state when resuming (don't increment listen count)"""
-        # Only clear the pause state, don't increment listened_count
-        # The listen count should only increment on initial play, not on resume
-        pass
-
     @property
     def is_completed(self):
         """Check if lesson has been completed (sticky once true)."""
@@ -162,8 +156,9 @@ class DailyAudioLesson(db.Model):
 
     @property
     def is_paused(self):
-        """Check if lesson is currently paused"""
-        return self.pause_position_seconds > 0 and not self.is_completed
+        """True when there's a saved playhead mid-lesson — independent of
+        completion, since a completed lesson can be replayed and paused."""
+        return self.pause_position_seconds > 0
 
     def display_title(self):
         """


### PR DESCRIPTION
## Summary
- Replaying a completed audio lesson from the start used to clear `completed_at`, erasing the fact that the user had finished it. Completion is now sticky: once set it stays set.
- Renamed the column to `last_completed_at` so the semantic is unambiguous (most recent completion timestamp; never reset to NULL once set).
- `update_lesson_state(action="resume")` no longer touches that column. It still bumps `listened_count` when restarting from the beginning, so replays remain measurable.
- Migration added: `tools/migrations/26-05-10--rename_daily_audio_completed_at.sql` (`ALTER TABLE ... CHANGE COLUMN`).
- Updated all DailyAudioLesson references: model property/methods, past-lessons serializer, `user_stats.py` queries (12 sites), and the completion-notification email template.

## Test plan
- [ ] Run migration on staging
- [ ] Listen to a fresh lesson to completion → `last_completed_at` is set; UI shows green
- [ ] Re-listen the completed lesson from the start → server bumps `listened_count`; `last_completed_at` is preserved; UI keeps green title and shows the orange progress bar
- [ ] Pause mid-listen of the replay → `pause_position_seconds` updates; completion still set
- [ ] Spot-check user-stats endpoints (recent lessons, monthly summary, leaderboards) still return data with `last_completed_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)