### PR TITLE
Auto-MWE article+noun pairs across enabled languages

### DIFF
--- a/zeeguu/core/mwe/stanza_mwe_detector.py
+++ b/zeeguu/core/mwe/stanza_mwe_detector.py
@@ -209,6 +209,19 @@ class GermanicStrategy(StanzaMWEStrategy):
                     mwe_type = "grammatical"
                     head_idx = self._convert_head_to_index(head)
 
+            # Article + noun: tapping the article alone returns nonsense
+            # because alignment fuses it into the noun's translation
+            # (e.g. da "en kikkert" -> "binoculars").
+            elif dep == "det":
+                candidate = self._convert_head_to_index(head)
+                if (
+                    candidate is not None
+                    and 0 <= candidate < len(tokens)
+                    and tokens[candidate].get("pos") in ("NOUN", "PROPN")
+                ):
+                    mwe_type = "article_noun"
+                    head_idx = candidate
+
             if mwe_type and head_idx is not None and head_idx != i:
                 if not (0 <= head_idx < len(tokens)):
                     continue

--- a/zeeguu/core/mwe/stanza_mwe_detector.py
+++ b/zeeguu/core/mwe/stanza_mwe_detector.py
@@ -26,6 +26,26 @@ from typing import List, Dict, Any
 from abc import ABC, abstractmethod
 
 
+def match_article_noun(tokens: List[Dict], head):
+    """
+    DET pointing at a NOUN/PROPN. Tapping the article alone returns nonsense
+    because alignment fuses it into the noun's translation
+    (e.g. da "en kikkert" -> "binoculars", el "ο ηθοποιός" -> "actor",
+    fr "le chocolat" -> often dropped to "chocolate").
+    Returns (mwe_type, head_idx) or (None, None). `head` is the 1-based
+    Stanza head value; 0 means ROOT.
+    """
+    if head is None or head == 0:
+        return None, None
+    candidate = head - 1
+    if (
+        0 <= candidate < len(tokens)
+        and tokens[candidate].get("pos") in ("NOUN", "PROPN")
+    ):
+        return "article_noun", candidate
+    return None, None
+
+
 class MWEStrategy(ABC):
     """Base class for MWE detection strategies."""
 
@@ -94,6 +114,10 @@ class StanzaMWEStrategy(MWEStrategy):
             elif pos == "PART" and dep == "advmod":
                 mwe_type = "negation"
                 head_idx = self._convert_head_to_index(head)
+
+            # Article + noun
+            elif dep == "det":
+                mwe_type, head_idx = match_article_noun(tokens, head)
 
             if mwe_type and head_idx is not None and head_idx != i:
                 # Validate head_idx is within bounds
@@ -209,18 +233,9 @@ class GermanicStrategy(StanzaMWEStrategy):
                     mwe_type = "grammatical"
                     head_idx = self._convert_head_to_index(head)
 
-            # Article + noun: tapping the article alone returns nonsense
-            # because alignment fuses it into the noun's translation
-            # (e.g. da "en kikkert" -> "binoculars").
+            # Article + noun
             elif dep == "det":
-                candidate = self._convert_head_to_index(head)
-                if (
-                    candidate is not None
-                    and 0 <= candidate < len(tokens)
-                    and tokens[candidate].get("pos") in ("NOUN", "PROPN")
-                ):
-                    mwe_type = "article_noun"
-                    head_idx = candidate
+                mwe_type, head_idx = match_article_noun(tokens, head)
 
             if mwe_type and head_idx is not None and head_idx != i:
                 if not (0 <= head_idx < len(tokens)):
@@ -318,7 +333,7 @@ class AuxOnlyStrategy(MWEStrategy):
     VERB_DEPS = {"aux", "expl", "expl:pv", "expl:pass"}
 
     def detect(self, tokens: List[Dict]) -> List[Dict]:
-        """Detect aux+verb and clitic+verb groups."""
+        """Detect aux+verb, clitic+verb, and article+noun groups."""
         mwe_groups = []
         processed_indices = set()
 
@@ -329,39 +344,42 @@ class AuxOnlyStrategy(MWEStrategy):
             dep = token.get("dep") or ""
             head = token.get("head")  # 1-based index, 0 = ROOT
 
+            mwe_type = None
+            head_idx = None
+
             # Detect aux and reflexive clitic relationships
-            should_group = (
-                dep in self.VERB_DEPS or
-                dep.startswith("aux:") or
-                dep.startswith("expl:")
-            )
+            if (
+                dep in self.VERB_DEPS
+                or dep.startswith("aux:")
+                or dep.startswith("expl:")
+            ):
+                candidate = self._convert_head_to_index(head)
+                if (
+                    candidate is not None
+                    and 0 <= candidate < len(tokens)
+                    and tokens[candidate].get("pos") in ("VERB", "AUX")
+                ):
+                    mwe_type = "aux_verb"
+                    head_idx = candidate
 
-            if should_group:
-                head_idx = self._convert_head_to_index(head)
+            # Article + noun (Romance / Romanian indefinite "un"/"o")
+            elif dep == "det":
+                mwe_type, head_idx = match_article_noun(tokens, head)
 
-                if head_idx is not None and head_idx != i:
-                    if not (0 <= head_idx < len(tokens)):
-                        continue
+            if mwe_type and head_idx is not None and head_idx != i:
+                existing_group = self._find_group_by_head(mwe_groups, head_idx)
 
-                    # Check if head is actually a verb
-                    head_pos = tokens[head_idx].get("pos", "")
-                    if head_pos not in ("VERB", "AUX"):
-                        continue
+                if existing_group:
+                    if i not in existing_group["dependent_indices"]:
+                        existing_group["dependent_indices"].append(i)
+                else:
+                    mwe_groups.append({
+                        "head_idx": head_idx,
+                        "dependent_indices": [i],
+                        "type": mwe_type,
+                    })
 
-                    # Check if we already have a group for this head
-                    existing_group = self._find_group_by_head(mwe_groups, head_idx)
-
-                    if existing_group:
-                        if i not in existing_group["dependent_indices"]:
-                            existing_group["dependent_indices"].append(i)
-                    else:
-                        mwe_groups.append({
-                            "head_idx": head_idx,
-                            "dependent_indices": [i],
-                            "type": "aux_verb"  # New type for aux+verb
-                        })
-
-                    processed_indices.add(i)
+                processed_indices.add(i)
 
         return mwe_groups
 

--- a/zeeguu/core/test/test_article_noun_mwe.py
+++ b/zeeguu/core/test/test_article_noun_mwe.py
@@ -1,0 +1,61 @@
+from unittest import TestCase
+
+from zeeguu.core.mwe.stanza_mwe_detector import GermanicStrategy
+
+
+def tok(text, pos, dep=None, head=None):
+    return {"text": text, "pos": pos, "dep": dep, "head": head, "lemma": text}
+
+
+class ArticleNounMWETest(TestCase):
+    def setUp(self):
+        self.strategy = GermanicStrategy()
+
+    def test_article_noun_detected(self):
+        # "en kikkert" -> head=kikkert (index 2 -> 1-based), en's head=2 (kikkert)
+        tokens = [
+            tok("Med", "ADP", dep="case", head=3),
+            tok("en", "DET", dep="det", head=3),
+            tok("kikkert", "NOUN", dep="obl", head=0),
+        ]
+        groups = self.strategy.detect(tokens)
+        article_groups = [g for g in groups if g["type"] == "article_noun"]
+        self.assertEqual(len(article_groups), 1)
+        g = article_groups[0]
+        self.assertEqual(g["head_idx"], 2)  # kikkert
+        self.assertIn(1, g["dependent_indices"])  # en
+
+    def test_det_pointing_at_non_noun_not_grouped(self):
+        # "den" pointing at an adjective should not produce article_noun
+        tokens = [
+            tok("den", "DET", dep="det", head=2),
+            tok("røde", "ADJ", dep="amod", head=0),
+        ]
+        groups = self.strategy.detect(tokens)
+        article_groups = [g for g in groups if g["type"] == "article_noun"]
+        self.assertEqual(len(article_groups), 0)
+
+    def test_article_adj_noun_includes_adjective_via_postprocess(self):
+        # "en lille prik" — DET+ADJ+NOUN, adjective sits between in indices.
+        # Post-processing for separated MWEs pulls it in (gap of 1 word).
+        tokens = [
+            tok("en", "DET", dep="det", head=3),
+            tok("lille", "ADJ", dep="amod", head=3),
+            tok("prik", "NOUN", dep="obl", head=0),
+        ]
+        groups = self.strategy.detect(tokens)
+        article_groups = [g for g in groups if g["type"] == "article_noun"]
+        self.assertEqual(len(article_groups), 1)
+        g = article_groups[0]
+        self.assertEqual(g["head_idx"], 2)  # prik
+        # Both 0 (en) and 1 (lille) should end up in dependent_indices —
+        # 0 directly from the det relation, 1 via the gap-fill post-process.
+        self.assertEqual(set(g["dependent_indices"]), {0, 1})
+
+    def test_no_det_no_article_noun(self):
+        tokens = [
+            tok("Venus", "PROPN", dep="nsubj", head=2),
+            tok("lyser", "VERB", dep="root", head=0),
+        ]
+        groups = self.strategy.detect(tokens)
+        self.assertEqual([g for g in groups if g["type"] == "article_noun"], [])

--- a/zeeguu/core/test/test_article_noun_mwe.py
+++ b/zeeguu/core/test/test_article_noun_mwe.py
@@ -1,6 +1,10 @@
 from unittest import TestCase
 
-from zeeguu.core.mwe.stanza_mwe_detector import GermanicStrategy
+from zeeguu.core.mwe.stanza_mwe_detector import (
+    AuxOnlyStrategy,
+    GermanicStrategy,
+    GreekStrategy,
+)
 
 
 def tok(text, pos, dep=None, head=None):
@@ -56,6 +60,56 @@ class ArticleNounMWETest(TestCase):
         tokens = [
             tok("Venus", "PROPN", dep="nsubj", head=2),
             tok("lyser", "VERB", dep="root", head=0),
+        ]
+        groups = self.strategy.detect(tokens)
+        self.assertEqual([g for g in groups if g["type"] == "article_noun"], [])
+
+
+class ArticleNounMWEGreekTest(TestCase):
+    """Greek inherits the base StanzaMWEStrategy.detect(), so this verifies
+    the shared `match_article_noun` helper fires for non-Germanic strategies
+    too."""
+
+    def setUp(self):
+        self.strategy = GreekStrategy()
+
+    def test_greek_article_noun(self):
+        # "Ο ηθοποιός" (the actor): "Ο" is DET head=2 (1-based) -> "ηθοποιός" NOUN
+        tokens = [
+            tok("Ο", "DET", dep="det", head=2),
+            tok("ηθοποιός", "NOUN", dep="root", head=0),
+        ]
+        groups = self.strategy.detect(tokens)
+        article_groups = [g for g in groups if g["type"] == "article_noun"]
+        self.assertEqual(len(article_groups), 1)
+        self.assertEqual(article_groups[0]["head_idx"], 1)
+        self.assertIn(0, article_groups[0]["dependent_indices"])
+
+
+class ArticleNounMWERomanceTest(TestCase):
+    """AuxOnlyStrategy is a separate hierarchy (Romance + Romanian).
+    This verifies the article+noun branch fires there too."""
+
+    def setUp(self):
+        self.strategy = AuxOnlyStrategy()
+
+    def test_french_le_chat(self):
+        # "le chat" (the cat): "le" DET head=2 (1-based) -> "chat" NOUN
+        tokens = [
+            tok("le", "DET", dep="det", head=2),
+            tok("chat", "NOUN", dep="root", head=0),
+        ]
+        groups = self.strategy.detect(tokens)
+        article_groups = [g for g in groups if g["type"] == "article_noun"]
+        self.assertEqual(len(article_groups), 1)
+        self.assertEqual(article_groups[0]["head_idx"], 1)
+        self.assertIn(0, article_groups[0]["dependent_indices"])
+
+    def test_no_article_noun_for_det_at_non_noun(self):
+        # DET pointing at a verb (unusual but exercises the guard).
+        tokens = [
+            tok("le", "DET", dep="det", head=2),
+            tok("court", "VERB", dep="root", head=0),
         ]
         groups = self.strategy.detect(tokens)
         self.assertEqual([g for g in groups if g["type"] == "article_noun"], [])


### PR DESCRIPTION
## Summary
- Tapping an article (Danish `en` in `en kikkert`, Greek `Ο` in `Ο γέρος ηθοποιός`, French `le` in `le chat`, etc.) was returning nonsense because Azure word-alignment fuses the article into the noun's target. Frontend trim + Azure detector fixes from #604 didn't catch this class — alignment doesn't even report overlapping target spans for it; it just drops the noun from alignment entirely and assigns the noun's translation to the article.
- This PR catches the class at tokenization time. `DET → NOUN/PROPN` is now treated as an MWE (type `article_noun`) across **all enabled languages**: Germanic, Greek, Romance, Romanian. The existing reader path (Stanza-detected MWE → chip across both tokens → translate as phrase) handles the rest.

## Why this shape

We considered:
1. **Improve the Azure alignment merge detector** — Azure's `alignment.proj` doesn't report this case as a shared target span. The existing `_target_shared_with_longer_source` was never going to catch it without a fundamentally different "dropped neighbor" heuristic. Fragile.
2. **LLM-based MWE detection** — works for all classes but adds latency + cost per tap.
3. **Stanza DET+NOUN pass** (this PR). Deterministic, runs at article ingestion time (cached upstream), no per-tap cost. Trades over-tagging (every article+noun phrase gets a chip, including clean 1:1 pairs like Danish `en hund → a dog`, French `le chat → the cat`) for simplicity and predictability.

The over-tagging is acceptable: pedagogically meaningful (gender carrier), and the existing `disable_mwe_grouping` endpoint + `user_mwe_override` table handle ungroup out of the box — they're detector-agnostic.

## Architecture

`match_article_noun(tokens, head)` is now a module-level helper in `stanza_mwe_detector.py`. The DET+NOUN branch is invoked from:

- `StanzaMWEStrategy.detect()` (base): reaches Greek, Slavic, Turkish.
- `GermanicStrategy.detect()` (override): de, nl, sv, da, no, en.
- `AuxOnlyStrategy.detect()` (separate hierarchy): fr, es, it, pt, and via `super()` Romanian (ro).

Disabled languages (Slavic, Turkish) get the branch through inheritance but don't matter because they're not in `LANGUAGE_STRATEGIES`.

## Density samples

- **Danish Venus A2 article** (148 tokens): 4 article_noun groups — `dine øjne`, `en lille prik`, `en kikkert`, `en del`.
- **Greek "Ο ηθοποιός Δημήτρης Καλλιβωκάς…"** (from user screenshot, 3 sentences): 3 article_noun groups — `Ο γέρος`, `τη ζωή`, `Η γυναίκα`.

About 2-3% of tokens are part of an `article_noun` MWE. Not excessive.

## Cache invalidation note

Article tokenization is cached in `article_tokenization_cache`. Already-cached articles won't have `article_noun` groups until they're re-tokenized. Either bust the cache before deploy or accept gradual rollout as articles get re-fetched.

## Test plan
- [x] Unit tests: 7 cases covering Germanic, Greek, and Romance hierarchies; det-at-non-noun rejected.
- [x] `test_bookmark_positions.py` still green (7/7).
- [x] Sanity scripts on real Danish + Greek text: detects expected MWEs, no false positives.
- [ ] After deploy: tap `en` in `en kikkert` (Danish), `Ο` in `Ο γέρος` (Greek), `le` in `le chat` (French). Expect MWE chip across both tokens with merged translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)