### PR TITLE
Show originals to B2+ users so their feed isn't empty

### DIFF
--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -1183,6 +1183,15 @@ class User(db.Model):
         lang_info = UserLanguage.with_language_id(self.learned_language_id, self)
         return ["A1", "A2", "B1", "B2", "C1", "C2"][lang_info.cefr_level - 1]
 
+    def is_b2_or_higher_for_learned_language(self):
+        """B2+ users see thin (B2: ~10% of inventory) or zero (C1+) simplified
+        content, so the simplified-only feed leaves them empty. They should
+        see originals too."""
+        try:
+            return self.cefr_level_for_learned_language() in ("B2", "C1", "C2")
+        except Exception:
+            return False
+
     def get_all_languages(self):
         """Get all languages that this user has words in."""
         from zeeguu.core.model import Language, Phrase, Meaning, UserWord

--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -693,16 +693,20 @@ class UserArticle(db.Model):
 
                 # Don't show original articles that aren't simplified —
                 # for default users this would open externally, defeating
-                # the in-reader purpose. Two flags let originals through:
+                # the in-reader purpose. Three escape hatches let originals through:
                 # - show_non_simplified_articles: legacy opt-in for users
                 #   who want both originals and simplified in their feed.
                 # - always_open_externally: the new on-demand flow, where
                 #   originals are the feed default and simplified is only
                 #   used for articles the user has personal-copied.
+                # - B2+ level: simplified inventory tapers off (B2) or
+                #   doesn't exist (C1+), so simplified-only filtering would
+                #   leave the feed empty.
                 if not article.parent_article_id and not article.uploader_id:
                     if not (
                         user.has_feature("show_non_simplified_articles")
                         or user.has_feature("always_open_externally")
+                        or user.is_b2_or_higher_for_learned_language()
                     ):
                         continue
 


### PR DESCRIPTION
## Summary
- The simplified-only feed filter (`user_article.py:702-707`) lets originals through only for two narrow groups: `show_non_simplified_articles` (4 hardcoded user IDs) and `always_open_externally` (devs + 3 beta IDs + accounts `id >= 6367`).
- Every other user falls back to the simplified ladder, which tops out at B2 with thin inventory (~10% of recent articles) and has **zero** content at C1+. Any older account at B2 or above ends up with an empty feed.
- Add a third escape hatch — `is_b2_or_higher_for_learned_language()` — so B2+ users see originals regardless of the feature flags.

## How I got here
Tiago (id=4022, Danish, `cefr_level=5` → C1) hadn't opened an article in 3+ months despite logging in regularly. Inventory check: 731 unread B1 Danish articles in the last 14 days — but for a C1 user, only the originals are visible at all, and originals were filtered out.

Wider check: of 44 advanced users (cefr ≥ C1) active in the last 90 days, **39 had not opened an article in the last 30 days**. Breakdown by (lang, level):

| lang | cefr | total | unread last 30d |
|---|---|---|---|
| fr | C1 | 14 | 13 |
| en | C1 | 8 | 5 |
| fr | C2 | 5 | 5 |
| nl | C1 | 4 | 4 |
| en | C2 | 3 | 3 |
| da | C1 | 4 | 3 |
| es | C1 | 2 | 2 |

Same pattern across languages — these are real users who can't get to articles.

## Why B2 and not just C1
B2 has some simplified inventory (63 in last 14 days for Danish) but it's a small slice of the 519 B2 originals. Once a B2 user reads through it, their feed empties. C1/C2 have zero simplified. Treating B2+ as one class avoids a per-language threshold and keeps the fix simple.

## What this does not change
- A1–B1 users: unchanged. They still see simplified content as before.
- Users with `always_open_externally` already on: unchanged. They get originals via the existing flag.
- High school cohorts on simplified content: unchanged (assuming they're A1–B1).
- The longer-term direction of phasing out simplification entirely is decoupled from this fix.

## Test plan
- [x] Local: `User.find_by_id(4022).is_b2_or_higher_for_learned_language()` → True.
- [ ] Post-deploy: Tiago opens his feed → sees C1 Danish originals.
- [ ] Sanity-check an A2/B1 user's feed → unchanged (still simplified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)