### PR TITLE
Fall back to Microsoft contextual when Azure alignment is unsupported

### DIFF
--- a/zeeguu/core/translation_services/translator.py
+++ b/zeeguu/core/translation_services/translator.py
@@ -368,8 +368,14 @@ def _vote_single_word_translation(data):
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
+    def azure_with_fallback():
+        # Azure alignment doesn't support every language pair (e.g. fr→nl
+        # returns no alignment data). When it returns None, fall back to
+        # Microsoft's span-tag contextual call so this slot still votes.
+        return azure_alignment_contextual_translate(data) or microsoft_contextual_translate(data)
+
     funcs = {
-        "azure": lambda: azure_alignment_contextual_translate(data),
+        "azure": azure_with_fallback,
         "google": lambda: google_contextual_translate(data),
         "deepl": lambda: deepl_contextual_translate_cached(data),
     }
@@ -421,9 +427,13 @@ def _vote_single_word_translation(data):
     if winner_votes < 2:
         winner["disagreement"] = True
 
+    def _format_provider(name, r):
+        if not r:
+            return f"{name}=None"
+        return f"{name}={r.get('translation')!r}[{r.get('source', '?')}]"
+
     providers_summary = ", ".join(
-        f"{name}={r.get('translation') if r else 'None'}"
-        for name, r in results.items()
+        _format_provider(name, r) for name, r in results.items()
     )
     log(
         f"[TRANSLATION-DISAGREE] word='{data.get('word')}' "

--- a/zeeguu/core/translation_services/translator.py
+++ b/zeeguu/core/translation_services/translator.py
@@ -427,13 +427,8 @@ def _vote_single_word_translation(data):
     if winner_votes < 2:
         winner["disagreement"] = True
 
-    def _format_provider(name, r):
-        if not r:
-            return f"{name}=None"
-        return f"{name}={r.get('translation')!r}[{r.get('source', '?')}]"
-
     providers_summary = ", ".join(
-        _format_provider(name, r) for name, r in results.items()
+        _format_provider_summary(name, r) for name, r in results.items()
     )
     log(
         f"[TRANSLATION-DISAGREE] word='{data.get('word')}' "
@@ -443,6 +438,13 @@ def _vote_single_word_translation(data):
         f"disagreement={winner.get('disagreement', False)}"
     )
     return winner
+
+
+def _format_provider_summary(name, result):
+    """Render one provider's vote for the [TRANSLATION-DISAGREE] log line."""
+    if not result:
+        return f"{name}=None"
+    return f"{name}={result.get('translation')!r}[{result.get('source', '?')}]"
 
 
 def _source_to_provider(result_dict):


### PR DESCRIPTION
## Context

After the 3-way voter (zeeguu/api#607) shipped, `[TRANSLATION-DISAGREE]` logs showed `azure=None` for *every single* fr→nl tap. Investigation revealed Azure's Translator API simply doesn't return alignment data for the fr↔nl pair (response has `alignment = None` entirely, not just empty `proj`). Our `translate_word_with_alignment` correctly returns None when alignment is missing — it just happens silently. Net effect: every fr→nl tap was effectively 2-way (Google + DeepL), and any G/D disagreement triggered the menu auto-open.

## Change

When `azure_alignment_contextual_translate` returns `None`, the voter now falls back to `microsoft_contextual_translate` (the span-tag contextual call we already use). Same provider account, different alignment mechanism — works for every language pair Azure supports at all.

```python
def azure_with_fallback():
    return azure_alignment_contextual_translate(data) or microsoft_contextual_translate(data)
```

Also augments the `[TRANSLATION-DISAGREE]` log line to include each provider's source label so we can grep `[Microsoft - alignment]` vs `[Microsoft - with context]` to see which Azure path actually voted.

## Before / after

`devant` in `Une foule devant le tribunal de Paris.` (fr→nl):

| Before | After |
| --- | --- |
| `providers=[azure=None, google='voor', deepl='naar'] disagreement=True` | `providers=[azure='voor'[Microsoft - with context], google='buiten', deepl='voor'] disagreement=False` |
| Menu auto-opens | Menu stays closed (2-of-3 majority for "voor") |

For `da→en` and other pairs where Azure alignment works, behaviour is unchanged — the `or` short-circuits and Microsoft contextual is never called.

## Test plan

- [ ] Tap an fr→nl word that previously logged `azure=None` — confirm new log shows `azure='...'[Microsoft - with context]` and that the voter reaches a majority more often.
- [ ] Tap a da→en word — confirm Azure alignment still wins via `[Microsoft - alignment]` in the log, no regression.
- [ ] No double-charge on Microsoft API: the alternatives-menu code path calls `microsoft_contextual_translate` independently with the same `data`; `@cache_on_data_keys` should hit the cache on the second call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)