### PR TITLE
Run LLM cleanup on original article content before storing

### DIFF
--- a/zeeguu/core/llm_services/simplification_service.py
+++ b/zeeguu/core/llm_services/simplification_service.py
@@ -8,6 +8,11 @@ from typing import Dict, Optional, Tuple
 from zeeguu.logging import log
 from zeeguu.core.llm_services.haiku_client import haiku_completion
 
+# Cleanup-pass guardrails (see cleanup_article_content)
+CLEANUP_MIN_BODY_CHARS = 500
+CLEANUP_MAX_GROWTH = 1.1
+CLEANUP_MIN_RETENTION = 0.5
+
 
 class SimplificationService:
     """Service for text simplification using LLM fallback chain (Anthropic → DeepSeek)"""
@@ -339,6 +344,76 @@ TOPIC: Business"""
                 return None
 
         return (cefr_level, topic)
+
+    def cleanup_article_content(
+        self,
+        html_content: str,
+        title: str,
+    ) -> Optional[Dict[str, str]]:
+        """
+        Strip leftover noise from a scraped article (audio/share widgets,
+        related-article link lists, ad text, etc.) and return cleaned
+        HTML plus a plain-text version derived from it.
+
+        Returns None on any failure — callers MUST fall back to the
+        original content so a flaky LLM never blocks article ingestion.
+        """
+        from bs4 import BeautifulSoup
+
+        if len(html_content or "") < CLEANUP_MIN_BODY_CHARS:
+            return None
+
+        original_text_len = len(BeautifulSoup(html_content, "html.parser").get_text())
+
+        prompt = f"""You are cleaning a scraped article before it is shown to a language learner.
+
+Remove ONLY clearly non-article material:
+- Audio/share/save/bookmark widget labels ("Listen to the article", "Share", "Save", "Print")
+- Newsletter signup blurbs, app-promo lines, paywall teasers
+- "Related articles" / "Read more" / "You might also like" link lists
+- Author bio boxes and "About the author" footers
+- Comment-section headers, social handles, cookie/consent banners
+- Image/video captions that are NOT integral to the body (UI labels, photographer credits)
+- Ad text and sponsored-content markers
+
+Keep ALL real article content: headlines, dek/standfirst, body paragraphs, pull quotes, in-body lists, integral captions, bylines that appear inside the body.
+
+Do NOT translate, simplify, summarize, paraphrase, or reorder. Only remove non-article fragments. Preserve paragraph breaks and the existing HTML structure.
+
+Title: {title}
+
+HTML:
+{html_content}
+
+Respond ONLY with the cleaned HTML — no prose, no markdown fences, no JSON wrapper."""
+
+        raw = haiku_completion(prompt, max_tokens=8000)
+        if not raw:
+            return None
+
+        cleaned_html = (
+            raw.strip()
+            .removeprefix("```html")
+            .removeprefix("```")
+            .removesuffix("```")
+            .strip()
+        )
+        if not cleaned_html:
+            log("Anthropic cleanup returned empty payload")
+            return None
+
+        cleaned_text = BeautifulSoup(cleaned_html, "html.parser").get_text()
+        if (
+            len(cleaned_text) > original_text_len * CLEANUP_MAX_GROWTH
+            or len(cleaned_text) < original_text_len * CLEANUP_MIN_RETENTION
+        ):
+            log(
+                f"Anthropic cleanup length out of bounds "
+                f"({original_text_len} -> {len(cleaned_text)}); keeping original"
+            )
+            return None
+
+        return {"html": cleaned_html, "text": cleaned_text}
 
     def _assess_cefr_deepseek(
         self, title: str, content: str, language_code: str

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -1390,6 +1390,23 @@ class Article(db.Model):
             print(f"-- detected language '{lang}' is not supported in Zeeguu")
             raise  # Re-raise to be caught as NoResultFound in endpoint
 
+        # LLM cleanup of leftover scraper noise (ads, "Listen to the article"
+        # buttons, related-article links). Gated to the send-to-Zeeguu path
+        # only — crawler ingestion is being phased out and shouldn't pay the
+        # per-article Haiku cost.
+        if source_upload_id is not None and html_content:
+            from zeeguu.core.llm_services.simplification_service import (
+                get_simplification_service,
+            )
+
+            cleaned = get_simplification_service().cleanup_article_content(
+                html_content=html_content,
+                title=title or "",
+            )
+            if cleaned:
+                html_content = cleaned["html"]
+                article_text = cleaned["text"]
+
         # Create new article and save it to DB
         url_object = Url.find_or_create(session, canonical_url)
         source_type = SourceType.find_by_type(SourceType.ARTICLE)


### PR DESCRIPTION
## Summary
- Adds `cleanup_article_content()` on `SimplificationService` — a Haiku pass that strips leftover scraper noise (audio/share widgets, "Listen to the article" buttons, related-article link lists, newsletter blurbs, ad text, cookie banners) from the body returned by the readability server.
- Wires it into `Article.find_or_create()` between language detection and `Source.find_or_create()`, so both the upload-with-text path and the readability path get cleaned. The cleaned versions are what land in `Source.content` and `Article.htmlContent`, so the reader sees a clean article on first open.
- Synchronous on the send-to-Zeeguu path. Latency is acceptable; junk on first read isn't.

## Why
With the reading-flow flip toward send-to-Zeeguu as the default and full-article-externally being torn out, the original-content view becomes the primary read path — so the leftover noise that readability + the regex `cleanup_non_content_bits()` miss is now what every learner sees. A real example that prompted this: an article opened with "Listen to the article" appearing inline in the body because the source page had a TTS-button caption that readability kept.

## Design notes
- **Fail-soft**: any LLM error returns `None` and the original content is kept. The ingestion path never breaks on a flaky API.
- **Guardrails to avoid hallucination/over-deletion**:
  - skip bodies under 500 chars (not worth the latency, rarely have junk)
  - skip if `ANTHROPIC_TEXT_SIMPLIFICATION_KEY` is unset
  - reject the result if cleaned text is >110% or <50% of original length
- **Prompt is conservative**: model is told to remove only clearly non-article fragments, not to translate / simplify / summarize / reorder.
- **Not addressed in this PR** (deliberately, to keep scope small):
  - French crawl-path bundling (cleanup-then-simplify in one LLM call for the existing crawl-time pipeline)
  - Completeness signal + filter-from-recommendations for articles that rely on missing interactive content

## Test plan
- [ ] Send a noisy article (e.g. one with a "Listen to the article" button visible in the body) via the extension/share flow and confirm the reader view no longer shows the widget text
- [ ] Send an article on a domain that already cleans well — confirm no over-deletion (no missing paragraphs) and that the guardrail keeps the original when cleanup goes wrong
- [ ] Send a very short article (<500 chars body) and confirm cleanup is skipped (no extra latency)
- [ ] With `ANTHROPIC_TEXT_SIMPLIFICATION_KEY` unset, confirm ingestion still works and the original content is kept
- [ ] Watch logs for `Anthropic cleanup ...` lines on staging before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)