### PR TITLE
Re-synthesize meaning audio when MP3 missing on disk

### DIFF
--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -178,6 +178,19 @@ class DailyLessonGenerator:
             meaning=meaning, teacher_language=teacher_lang
         )
         if existing_lesson:
+            fs_path = ZEEGUU_DATA_FOLDER + existing_lesson.audio_file_path
+            if os.path.exists(fs_path):
+                return existing_lesson
+            log(
+                f"[generate_audio_lesson_meaning] DB row {existing_lesson.id} exists but audio file missing at {fs_path}; re-synthesizing from stored script"
+            )
+            self.voice_synthesizer.generate_lesson_audio(
+                meaning_id=meaning.id,
+                teacher_language_code=translation_language,
+                script=existing_lesson.script,
+                language_code=origin_language,
+                cefr_level=cefr_level,
+            )
             return existing_lesson
 
         # Update progress: generating script


### PR DESCRIPTION
## Summary
- When an `AudioLessonMeaning` DB row exists but the MP3 file is missing, re-synthesize from the stored script and return the existing row, instead of returning the row unconditionally.
- Closes a silent-failure gap where `lesson_builder` would log a warning, drop the missing audio, and still emit the transition phrase — producing daily lessons that played only "let's move on to the next word" with no word between transitions.

## Background
Commit 20f55ac5 (Apr 5) changed the meaning-lesson filename convention from `{id}-{lang}.mp3` to `meaning-{id}-{lang}.mp3` but didn't migrate existing files. Today a user got a 3-word Danish lesson where all three meanings pre-dated the rename, so the orphaned files were never resolved and the lesson came out as 3 transitions and nothing else.

The 6,188 orphaned files have already been renamed on production. This patch is the defense-in-depth so the same silent failure can't recur (deleted file, lost in a restore, etc.).

## Test plan
- [ ] Manually delete a `meaning-*.mp3` for a known `AudioLessonMeaning`, generate a daily lesson that includes it, verify the audio is re-synthesized and the lesson plays the word.
- [ ] Generate a daily lesson with meanings that have both row + file present; verify no spurious re-synth (no log line, no Google TTS call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)