### PR TITLE
Articles: simplified version supersedes the original for the user

### DIFF
--- a/zeeguu/api/endpoints/user_articles.py
+++ b/zeeguu/api/endpoints/user_articles.py
@@ -56,18 +56,18 @@ def user_articles_recommended(count: int = 15, page: int = 0):
     # Collect article IDs to exclude
     articles_to_exclude = []
 
+    # Always exclude originals when the user has saved a simplified child of
+    # them — the user moved past the original, recycling it is noise.
+    saved_for_user = PersonalCopy.all_for(user)
+    for article in saved_for_user:
+        if article.parent_article_id:
+            articles_to_exclude.append(article.parent_article_id)
+
     if exclude_saved:
-        # Get all saved articles for the user
-        saved_articles = PersonalCopy.all_for(user)
-
-        # Exclude both the PersonalCopy article IDs and their parent article IDs
-        for article in saved_articles:
-            # Add the PersonalCopy article ID
+        # Also exclude the saved articles themselves (and their parents,
+        # already covered above for simplifications).
+        for article in saved_for_user:
             articles_to_exclude.append(article.id)
-
-            # If this is a simplified version, also exclude the original article
-            if article.parent_article_id:
-                articles_to_exclude.append(article.parent_article_id)
 
     # Always exclude hidden articles from recommendations
     hidden_user_articles = (
@@ -139,6 +139,13 @@ def saved_articles(page: int = None):
         saves = PersonalCopy.get_page_for(user, page)
     else:
         saves = PersonalCopy.all_for(user)
+
+    # Hide the original when the user has also saved a simplified child of
+    # it — the simplified version is the one they actually want to read.
+    parent_ids_with_saved_simpl = {
+        a.parent_article_id for a in saves if a.parent_article_id is not None
+    }
+    saves = [a for a in saves if a.id not in parent_ids_with_saved_simpl]
 
     article_infos = UserArticle.article_infos(user, saves, select_appropriate=True)
 

--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -407,7 +407,7 @@ class UserArticle(db.Model):
 
     @classmethod
     def user_article_info(
-        cls, user: User, article: Article, with_content=False, with_translations=True, with_summary=True, tokenization_cache=None
+        cls, user: User, article: Article, with_content=False, with_translations=True, with_summary=True, tokenization_cache=None, simplified_pc_by_parent=None
     ):
         """
         Returns user-specific article information for the given article.
@@ -535,16 +535,22 @@ class UserArticle(db.Model):
         # simplified child of it (auto-saved when they tap Simplify), expose
         # that id so the feed/saved-list can route the Open button to the
         # in-app readable version instead of the external original.
+        # Prefer the precomputed dict (batched by article_infos) over a
+        # per-article query — list endpoints would otherwise N+1 here.
         if not article.parent_article_id:
-            simplified_pc = (
-                PersonalCopy.query
-                .join(Article, PersonalCopy.article_id == Article.id)
-                .filter(Article.parent_article_id == article.id)
-                .filter(PersonalCopy.user_id == user.id)
-                .first()
-            )
-            if simplified_pc:
-                returned_info["user_simplified_article_id"] = simplified_pc.article_id
+            if simplified_pc_by_parent is not None:
+                simplified_id = simplified_pc_by_parent.get(article.id)
+            else:
+                simplified_pc = (
+                    PersonalCopy.query
+                    .join(Article, PersonalCopy.article_id == Article.id)
+                    .filter(Article.parent_article_id == article.id)
+                    .filter(PersonalCopy.user_id == user.id)
+                    .first()
+                )
+                simplified_id = simplified_pc.article_id if simplified_pc else None
+            if simplified_id:
+                returned_info["user_simplified_article_id"] = simplified_id
 
         # Clear MWE metadata from tokens that user has disabled
         # This is done on backend to keep frontend simple (ADR 009)
@@ -758,8 +764,27 @@ class UserArticle(db.Model):
         # Step 4: Commit all cache writes
         db.session.commit()
 
+        # Batch-fetch simplified-child PersonalCopies for any originals in
+        # this list so user_article_info doesn't run a per-article query
+        # (N+1 on every feed/saved page load).
+        simplified_pc_by_parent = {}
+        rows = (
+            db.session.query(Article.parent_article_id, PersonalCopy.article_id)
+            .join(PersonalCopy, PersonalCopy.article_id == Article.id)
+            .filter(Article.parent_article_id.in_(article_ids))
+            .filter(PersonalCopy.user_id == user.id)
+            .all()
+        )
+        for parent_id, simplified_article_id in rows:
+            simplified_pc_by_parent[parent_id] = simplified_article_id
+
         # Step 5: Build response infos (pure reads, using pre-fetched caches)
         return [
-            cls.user_article_info(user, article, tokenization_cache=existing_caches.get(article.id))
+            cls.user_article_info(
+                user,
+                article,
+                tokenization_cache=existing_caches.get(article.id),
+                simplified_pc_by_parent=simplified_pc_by_parent,
+            )
             for article in articles_to_process
         ]

--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -278,6 +278,13 @@ class UserArticle(db.Model):
             if each.last_interaction() is not None
         ]
 
+        # Hide the original when the user also has a simplified child of it
+        # in this list — the simplified version is the one they want to read.
+        parent_ids_with_saved_simpl = {
+            a.parent_article_id for a in articles if a.parent_article_id is not None
+        }
+        articles = [a for a in articles if a.id not in parent_ids_with_saved_simpl]
+
         return cls.article_infos(user, articles, select_appropriate=False)
 
     @classmethod
@@ -523,6 +530,21 @@ class UserArticle(db.Model):
                 is not None
             )
         returned_info["has_personal_copy"] = bool(has_pc)
+
+        # If this is an original article and the user has already saved a
+        # simplified child of it (auto-saved when they tap Simplify), expose
+        # that id so the feed/saved-list can route the Open button to the
+        # in-app readable version instead of the external original.
+        if not article.parent_article_id:
+            simplified_pc = (
+                PersonalCopy.query
+                .join(Article, PersonalCopy.article_id == Article.id)
+                .filter(Article.parent_article_id == article.id)
+                .filter(PersonalCopy.user_id == user.id)
+                .first()
+            )
+            if simplified_pc:
+                returned_info["user_simplified_article_id"] = simplified_pc.article_id
 
         # Clear MWE metadata from tokens that user has disabled
         # This is done on backend to keep frontend simple (ADR 009)


### PR DESCRIPTION
## Summary

When a user simplifies an article, the original becomes noise — the user has moved past it and the simplified child is what they want to read. Today the original keeps appearing in both Discover and My Articles, and its Open button still routes externally because the original has no in-app readable body. This PR makes the original disappear, and adds the field the web companion PR needs to route Open to the simplified child in-app.

- **\`user_article_info\` now sets \`user_simplified_article_id\`** — populated when the current user has saved any simplification of this article (PersonalCopy joined against \`Article.parent_article_id\`). Sits next to the existing parent-walk for \`has_personal_copy\`.
- **\`/user_articles/recommended\`** unconditionally excludes \`parent_article_id\` of any saved simplification — previously this only happened when callers passed \`exclude_saved=true\`. Users who simplified an article no longer see the original in the feed.
- **\`/user_articles/saved\` + \`UserArticle.all_starred_and_liked_articles_of_user_info\`** dedupe — when both an original and one of its simplifications are in the saved set, the original is dropped. Same logic in both because My Articles hits \`/user_articles/starred_or_liked\` (which calls the latter), not \`/user_articles/saved\`.

Companion: zeeguu/web#simplified-replaces-original

## Test plan

- [ ] Discover: simplify an article → leave to another tab → back to Discover → original no longer appears
- [ ] My Articles: same flow → only the simplified version is listed (with the existing "Simplified" tag)
- [ ] Articles that haven't been simplified are unaffected
- [ ] \`exclude_saved=true\` callers still work as before (now they get a strict superset of the exclusion they had)

🤖 Generated with [Claude Code](https://claude.com/claude-code)