### PR TITLE
Extract haiku_client; consolidate 4 Haiku POST sites

### DIFF
--- a/zeeguu/core/llm_services/grammar_correction_service.py
+++ b/zeeguu/core/llm_services/grammar_correction_service.py
@@ -10,10 +10,11 @@ import re
 import requests
 import time
 from zeeguu.logging import log
+from .haiku_client import HAIKU_MODEL, haiku_completion_or_raise
 from .prompts.grammar_correction import get_full_article_correction_prompt
 
 # Model names for tracking
-ANTHROPIC_CORRECTION_MODEL = "claude-haiku-4-5-20251001"
+ANTHROPIC_CORRECTION_MODEL = HAIKU_MODEL
 DEEPSEEK_CORRECTION_MODEL = "deepseek-chat"
 
 
@@ -137,36 +138,11 @@ class GrammarCorrectionService:
         log(f"Correcting article with Anthropic (single request)...")
         start_time = time.time()
 
-        headers = {
-            "x-api-key": self.anthropic_api_key,
-            "anthropic-version": "2023-06-01",
-            "Content-Type": "application/json",
-        }
+        result = haiku_completion_or_raise(
+            prompt, max_tokens=8000, temperature=0, timeout=90
+        ).strip()
 
-        data = {
-            "model": ANTHROPIC_CORRECTION_MODEL,
-            "messages": [{"role": "user", "content": prompt}],
-            "max_tokens": 8000,
-            "temperature": 0,  # Deterministic for corrections
-        }
-
-        response = requests.post(
-            "https://api.anthropic.com/v1/messages",
-            headers=headers,
-            json=data,
-            timeout=90,
-        )
-
-        duration = time.time() - start_time
-
-        if response.status_code != 200:
-            raise Exception(
-                f"Anthropic API error: {response.status_code} - {response.text}"
-            )
-
-        result = response.json()["content"][0]["text"].strip()
-        log(f"Anthropic correction completed in {duration:.2f}s")
-
+        log(f"Anthropic correction completed in {time.time() - start_time:.2f}s")
         return result
 
     def _correct_with_deepseek(self, prompt: str) -> str:

--- a/zeeguu/core/llm_services/haiku_client.py
+++ b/zeeguu/core/llm_services/haiku_client.py
@@ -1,0 +1,86 @@
+"""
+Shared client for one-shot completions against Anthropic's Haiku model.
+
+This is the "real-time, text-simplification key" Anthropic family,
+separate from the SDK-based `AnthropicService` (which uses
+ANTHROPIC_API_KEY + Sonnet for background pipelines).
+
+Two entry points:
+- haiku_completion: returns None on any failure (no key, network,
+  non-200, malformed payload). Use when the caller has a fail-soft
+  contract — e.g. article ingestion that must not block on a flaky LLM.
+- haiku_completion_or_raise: raises on failure. Use when the caller's
+  contract is "this MUST succeed" — e.g. an explicit user-initiated
+  correction request.
+"""
+
+import os
+from typing import Optional
+
+import requests
+from zeeguu.logging import log
+
+HAIKU_MODEL = "claude-haiku-4-5-20251001"
+ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+
+
+def _post(prompt: str, max_tokens: int, temperature: float, timeout: int) -> requests.Response:
+    api_key = os.environ.get("ANTHROPIC_TEXT_SIMPLIFICATION_KEY")
+    if not api_key:
+        raise RuntimeError("ANTHROPIC_TEXT_SIMPLIFICATION_KEY not set")
+    return requests.post(
+        ANTHROPIC_URL,
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "Content-Type": "application/json",
+        },
+        json={
+            "model": HAIKU_MODEL,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        },
+        timeout=timeout,
+    )
+
+
+def haiku_completion(
+    prompt: str,
+    max_tokens: int,
+    temperature: float = 0.0,
+    timeout: int = 30,
+) -> Optional[str]:
+    """
+    POST a single-turn prompt to Haiku. Returns the response text, or
+    None on any failure (key missing, network error, non-200,
+    malformed payload). Logs the failure.
+    """
+    try:
+        response = _post(prompt, max_tokens, temperature, timeout)
+        if response.status_code != 200:
+            log(f"Anthropic API error: {response.status_code}")
+            return None
+        return response.json()["content"][0]["text"]
+    except Exception as e:
+        log(f"Haiku completion failed: {e}")
+        return None
+
+
+def haiku_completion_or_raise(
+    prompt: str,
+    max_tokens: int,
+    temperature: float = 0.0,
+    timeout: int = 30,
+) -> str:
+    """
+    POST a single-turn prompt to Haiku. Returns the response text, or
+    raises on any failure. Use when caller expects an exception.
+    """
+    response = _post(prompt, max_tokens, temperature, timeout)
+    if response.status_code != 200:
+        raise Exception(
+            f"Anthropic API error: {response.status_code} - {response.text}"
+        )
+    return response.json()["content"][0]["text"]

--- a/zeeguu/core/llm_services/simplification_and_classification.py
+++ b/zeeguu/core/llm_services/simplification_and_classification.py
@@ -15,6 +15,7 @@ from requests.exceptions import Timeout, RequestException
 from zeeguu.logging import log
 from zeeguu.core.model.article import Article
 from zeeguu.core.model.url import Url
+from .haiku_client import HAIKU_MODEL, haiku_completion_or_raise
 from .prompts.article_simplification import get_adaptive_simplification_prompt
 
 
@@ -152,62 +153,39 @@ def simplify_article_adaptive_levels(
 
         if provider == "deepseek":
             model_name = "deepseek-chat"
-            headers = {
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            }
-            data = {
-                "model": model_name,
-                "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": 6000,
-                "temperature": 0.1,
-            }
             log(f"  Sending request to DeepSeek API...")
             response = requests.post(
                 "https://api.deepseek.com/v1/chat/completions",
-                headers=headers,
-                json=data,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": model_name,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "max_tokens": 6000,
+                    "temperature": 0.1,
+                },
                 timeout=180,
             )
+            api_duration = time.time() - api_start_time
+            log(
+                f"  DEEPSEEK API responded with status: {response.status_code} (took {api_duration:.2f} seconds)"
+            )
+            if response.status_code != 200:
+                raise Exception(
+                    f"DEEPSEEK API error: {response.status_code} - {response.text}"
+                )
+            result = response.json()["choices"][0]["message"]["content"].strip()
         else:  # anthropic
-            model_name = "claude-haiku-4-5-20251001"
-            headers = {
-                "x-api-key": api_key,
-                "anthropic-version": "2023-06-01",
-                "Content-Type": "application/json",
-            }
-            data = {
-                "model": model_name,
-                "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": 4000,
-                "temperature": 0.1,
-            }
+            model_name = HAIKU_MODEL
             log(f"  Sending request to Anthropic API...")
-            response = requests.post(
-                "https://api.anthropic.com/v1/messages",
-                headers=headers,
-                json=data,
-                timeout=180,
-            )
+            result = haiku_completion_or_raise(
+                prompt, max_tokens=4000, temperature=0.1, timeout=180
+            ).strip()
+            api_duration = time.time() - api_start_time
+            log(f"  ANTHROPIC API completed (took {api_duration:.2f} seconds)")
 
-        api_duration = time.time() - api_start_time
-        log(
-            f"  {provider.upper()} API responded with status: {response.status_code} (took {api_duration:.2f} seconds)"
-        )
-
-        if response.status_code != 200:
-            raise Exception(
-                f"{provider.upper()} API error: {response.status_code} - {response.text}"
-            )
-
-        log(f"  Parsing {provider.upper()} API response...")
-        response_json = response.json()
-
-        # Extract result based on provider
-        if provider == "deepseek":
-            result = response_json["choices"][0]["message"]["content"].strip()
-        else:  # anthropic
-            result = response_json["content"][0]["text"].strip()
         log(f"  Response length: {len(result)} characters")
 
         # Check if article is unfinished due to paywall

--- a/zeeguu/core/llm_services/simplification_service.py
+++ b/zeeguu/core/llm_services/simplification_service.py
@@ -6,6 +6,7 @@ import os
 import requests
 from typing import Dict, Optional, Tuple
 from zeeguu.logging import log
+from zeeguu.core.llm_services.haiku_client import haiku_completion
 
 
 class SimplificationService:
@@ -313,58 +314,31 @@ Example response:
 CEFR: B2
 TOPIC: Business"""
 
-        try:
-            response = requests.post(
-                "https://api.anthropic.com/v1/messages",
-                headers={
-                    "x-api-key": self.anthropic_api_key,
-                    "anthropic-version": "2023-06-01",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "model": "claude-haiku-4-5-20251001",
-                    "messages": [{"role": "user", "content": prompt}],
-                    "max_tokens": 30,
-                    "temperature": 0.1,
-                },
-                timeout=30,
-            )
+        raw = haiku_completion(prompt, max_tokens=30, temperature=0.1)
+        if not raw:
+            return None
+        result = raw.strip()
 
-            if response.status_code == 200:
-                result = response.json()["content"][0]["text"].strip()
-                # Parse the response to extract CEFR and topic
-                lines = result.split('\n')
-                cefr_level = None
-                topic = None
-                
-                for line in lines:
-                    if line.startswith("CEFR:"):
-                        cefr_level = line.replace("CEFR:", "").strip()
-                    elif line.startswith("TOPIC:"):
-                        topic = line.replace("TOPIC:", "").strip()
-                
-                # Validate CEFR level
-                cefr_levels = ["A1", "A2", "B1", "B2", "C1", "C2"]
-                if cefr_level not in cefr_levels:
-                    # Fallback: try to extract from anywhere in the response
-                    for level in cefr_levels:
-                        if level in result.upper():
-                            cefr_level = level
-                            break
-                    if not cefr_level:
-                        # Can't parse response - return None
-                        log(f"Could not extract valid CEFR level from Anthropic response: {result}")
-                        return None
+        cefr_level = None
+        topic = None
+        for line in result.split("\n"):
+            if line.startswith("CEFR:"):
+                cefr_level = line.replace("CEFR:", "").strip()
+            elif line.startswith("TOPIC:"):
+                topic = line.replace("TOPIC:", "").strip()
 
-                # For now, return a tuple with both values
-                return (cefr_level, topic)
-            else:
-                log(f"Anthropic API error: {response.status_code}")
+        cefr_levels = ["A1", "A2", "B1", "B2", "C1", "C2"]
+        if cefr_level not in cefr_levels:
+            # Last-ditch: grep the level out of unstructured output before giving up.
+            for level in cefr_levels:
+                if level in result.upper():
+                    cefr_level = level
+                    break
+            if cefr_level not in cefr_levels:
+                log(f"Could not extract valid CEFR level from Anthropic response: {result}")
                 return None
 
-        except Exception as e:
-            log(f"Error in Anthropic CEFR assessment: {e}")
-            return None
+        return (cefr_level, topic)
 
     def _assess_cefr_deepseek(
         self, title: str, content: str, language_code: str
@@ -771,69 +745,44 @@ SIMPLIFIED_TITLE: [your simplified title in {language_name}]
 SIMPLIFIED_SUMMARY: [a concise plain-text summary in {language_name}, maximum 25 words, NO Markdown or HTML]
 SIMPLIFIED_CONTENT: [your simplified content in {language_name} using Markdown formatting - preserve paragraph breaks with double newlines, use **bold**, *italics*, ## for headings, - for lists]"""
 
-        try:
-            response = requests.post(
-                "https://api.anthropic.com/v1/messages",
-                headers={
-                    "x-api-key": self.anthropic_api_key,
-                    "anthropic-version": "2023-06-01",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "model": "claude-haiku-4-5-20251001",
-                    "messages": [{"role": "user", "content": prompt}],
-                    "max_tokens": 2000,
-                    "temperature": 0.2,  # Lower temperature for more consistent results
-                },
-                timeout=60,
-            )
-
-            if response.status_code == 200:
-                result = response.json()["content"][0]["text"]
-
-                lines = result.split("\n")
-                simplified_title = None
-                simplified_summary = None
-                simplified_content = []
-                current_section = None
-
-                for line in lines:
-                    if line.startswith("SIMPLIFIED_TITLE:"):
-                        simplified_title = line.split(":", 1)[1].strip()
-                        current_section = None
-                    elif line.startswith("SIMPLIFIED_SUMMARY:"):
-                        simplified_summary = line.split(":", 1)[1].strip()
-                        current_section = None
-                    elif line.startswith("SIMPLIFIED_CONTENT:"):
-                        current_section = "content"
-                        content_start = line.split(":", 1)[1].strip()
-                        if content_start:
-                            simplified_content.append(content_start)
-                    elif current_section == "content":
-                        simplified_content.append(line.strip() if line.strip() else "")
-
-                simplified_text = "\n".join(simplified_content)
-                import re
-                simplified_text = re.sub(r"\n{3,}", "\n\n", simplified_text)
-
-                if simplified_title and simplified_text:
-                    import markdown2
-                    simplified_html = markdown2.markdown(
-                        simplified_text,
-                        extras=['break-on-newline', 'fenced-code-blocks', 'tables']
-                    )
-                    return simplified_title, simplified_html, simplified_summary
-                else:
-                    log("Failed to parse Anthropic response")
-                    return None, None, None
-
-            else:
-                log(f"Anthropic API error: {response.status_code}")
-                return None, None, None
-
-        except Exception as e:
-            log(f"Error creating simplified version with Anthropic: {e}")
+        result = haiku_completion(
+            prompt, max_tokens=2000, temperature=0.2, timeout=60
+        )
+        if not result:
             return None, None, None
+
+        simplified_title = None
+        simplified_summary = None
+        simplified_content = []
+        current_section = None
+        for line in result.split("\n"):
+            if line.startswith("SIMPLIFIED_TITLE:"):
+                simplified_title = line.split(":", 1)[1].strip()
+                current_section = None
+            elif line.startswith("SIMPLIFIED_SUMMARY:"):
+                simplified_summary = line.split(":", 1)[1].strip()
+                current_section = None
+            elif line.startswith("SIMPLIFIED_CONTENT:"):
+                current_section = "content"
+                content_start = line.split(":", 1)[1].strip()
+                if content_start:
+                    simplified_content.append(content_start)
+            elif current_section == "content":
+                simplified_content.append(line.strip() if line.strip() else "")
+
+        import re
+        simplified_text = re.sub(r"\n{3,}", "\n\n", "\n".join(simplified_content))
+
+        if not (simplified_title and simplified_text):
+            log("Failed to parse Anthropic response")
+            return None, None, None
+
+        import markdown2
+        simplified_html = markdown2.markdown(
+            simplified_text,
+            extras=["break-on-newline", "fenced-code-blocks", "tables"],
+        )
+        return simplified_title, simplified_html, simplified_summary
 
     def _simplify_deepseek(
         self, title: str, content: str, target_level: str, language_code: str


### PR DESCRIPTION
## Summary
Extract the duplicated \`requests.post\` to \`api.anthropic.com/v1/messages\` boilerplate into a shared module and migrate the 4 in-house callers that used it.

Foundation for #609 (article-cleanup pass), which is stacked on top and uses \`haiku_completion\` directly.

## New module
\`zeeguu/core/llm_services/haiku_client.py\`:
- \`haiku_completion(prompt, max_tokens, temperature=0.0, timeout=30)\` — returns text or \`None\` on any failure. For fail-soft callers.
- \`haiku_completion_or_raise(...)\` — same signature, raises on failure. For callers whose contract is "must succeed".
- \`HAIKU_MODEL\` constant.

## Migrated
- \`simplification_service.py\` — 2 callers (CEFR, simplify)
- \`grammar_correction_service._correct_with_anthropic\`
- \`simplification_and_classification\` Anthropic branch of \`_call_llm\`

## Deliberately not merged
- \`simplification_service._translate_and_adapt_anthropic\` — uses manual UTF-8 encoding via \`data=ensure_ascii=False\`. Genuine behavioral difference, kept as-is.
- \`AnthropicService\` (and \`translation_validator\`, \`mwe_translation_service\`) — these use the official \`anthropic\` SDK with \`ANTHROPIC_API_KEY\` + Sonnet 4.5. Different family ("background SDK" vs this PR's "real-time HTTP"), kept separate.

## Diff
4 files: 1 new module, 3 migrated. Net -97 lines across the migrated files.

## Test plan
- [ ] Trigger a simplification — verify Haiku branch of \`_call_llm\` still works
- [ ] Trigger CEFR assessment — verify cefr extraction still works
- [ ] Trigger grammar correction — verify \`_correct_with_anthropic\` raises cleanly on bad key
- [ ] Confirm \`_translate_and_adapt_anthropic\` is unchanged (UTF-8 path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)