### PR TITLE
Strip site-chrome metadata in the simplification prompt

### DIFF
--- a/zeeguu/core/llm_services/prompts/article_simplification.py
+++ b/zeeguu/core/llm_services/prompts/article_simplification.py
@@ -52,6 +52,19 @@ INSTRUCTIONS:
 7. If original is C1, create A1, A2, B1, and B2
 8. If original is C2, create A1, A2, B1, B2, and C1
 
+CONTENT CLEANUP (apply BEFORE simplifying — these elements must NOT appear in any simplified version):
+- Section/category breadcrumb headers that aren't the article's own heading (e.g. a standalone "Cannes 2026", "Sport", "Kultur", "Politik" line at the top)
+- Publication metadata: standalone dates, timestamps, byline-only date lines ("maj 2026 | 14:01", "Updated 14:30", "Published yesterday")
+- Photo / video / image credits ("Foto | X", "Photo: Y", "© Z", "Photo credit:", "Image:")
+- Audio / share / save / bookmark widget labels ("Lyt til artiklen", "Listen to the article", "Share", "Save", "Print")
+- "Related articles" / "Read more" / "You might also like" link lists (top OR bottom)
+- Newsletter signup blurbs, app-promo lines, paywall teasers
+- Cookie/consent banners, comment-section headers, social handles
+- Author bio boxes and "About the author" footers
+- Ad text and sponsored-content markers
+
+The article body proper begins at the first substantive paragraph. Discard everything above it that matches the categories above. Discard the same categories at the end. Keep the actual article heading, dek/standfirst, body paragraphs, pull quotes, in-body lists, and bylines that appear inside the running text.
+
 SIMPLIFICATION RULES:
 - PRESERVE ALL MAIN IDEAS: Every important concept from the original must appear in simplified versions
 - PRESERVE PARAGRAPH STRUCTURE: Transform each paragraph of the original into a paragraph in the simplified version


### PR DESCRIPTION
## Problem
Articles crawled from sites with prominent metadata headers (ekkofilm.dk's *"Cannes 2026 / maj 2026 | 14:01 / Foto | Mobra Films"*, etc.) get faithfully reproduced in every simplified version, because the simplifier was told to "preserve all main ideas / paragraph structure" but had no instruction about what's *not* an idea.

The cleanup pass in #609 only runs on the send-to-Zeeguu path (gated on \`source_upload_id\`). Crawler-ingested articles — which feed the adaptive-simplification path used by every language still on the crawl+simplify pipeline (Danish, French, ...) — skip cleanup entirely.

## Fix
Add an explicit \"CONTENT CLEANUP\" section to the adaptive simplification prompt, applied before simplification. Covers:
- Section/category breadcrumb headers (\"Cannes 2026\", \"Sport\", \"Kultur\")
- Publication dates / timestamps (\"maj 2026 | 14:01\", \"Updated 14:30\")
- Photo and video credits (\"Foto | X\", \"Photo: Y\", \"© Z\")
- Audio / share / save widget labels (\"Lyt til artiklen\", \"Listen to the article\")
- Related-article / Read-more link lists (top or bottom)
- Newsletter signup blurbs, cookie banners, author bio boxes, ad text

**Zero new LLM calls** — same simplification roundtrip, just discards the junk before producing each level.

## Not in this PR (deliberately)
The two single-level prompts in \`_simplify_anthropic\` / \`_simplify_deepseek\` inside \`simplification_service.py\`. Less-used paths; can get the same directive in a follow-up if needed.

## Test plan
- [ ] Re-trigger simplification on a fresh ekkofilm.dk article and confirm \"Cannes 2026\" / \"maj 2026 | 14:01\" / \"Foto | Mobra Films\" no longer appear at the top of any simplified version
- [ ] Sanity-check on a clean-source article (e.g. dr.dk) — no regression, real content untouched
- [ ] Spot-check French simplification — same prompt, should now strip equivalent French metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)