### PR TITLE
personal_copy.saved_at — record + expose save time

### DIFF
--- a/tools/migrations/26-05-20--add_personal_copy_saved_at.sql
+++ b/tools/migrations/26-05-20--add_personal_copy_saved_at.sql
@@ -1,0 +1,16 @@
+-- Track when each PersonalCopy was created, so the My Articles surface can
+-- render "Saved 2h ago" instead of falling back to the article's publish time
+-- (which is misleading on a save-sorted list).
+--
+-- New rows default to CURRENT_TIMESTAMP via the DB.
+-- Existing rows are backfilled from article.published_time as the best
+-- available proxy — most saves happen near publish, and any error is
+-- bounded by article age.
+
+ALTER TABLE personal_copy
+ADD COLUMN saved_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE personal_copy pc
+JOIN article a ON a.id = pc.article_id
+SET pc.saved_at = a.published_time
+WHERE a.published_time IS NOT NULL;

--- a/zeeguu/core/model/personal_copy.py
+++ b/zeeguu/core/model/personal_copy.py
@@ -1,6 +1,8 @@
+from datetime import datetime
+
 from zeeguu.core.model.article import Article
 from zeeguu.core.model.user import User
-from sqlalchemy import Column, Integer, ForeignKey, desc
+from sqlalchemy import Column, Integer, DateTime, ForeignKey, desc
 from sqlalchemy.orm import relationship
 
 import zeeguu
@@ -21,10 +23,13 @@ class PersonalCopy(db.Model):
     article_id = Column(Integer, ForeignKey(Article.id))
     article = relationship(Article)
 
+    saved_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
     def __init__(self, user, article):
 
         self.user = user
         self.article = article
+        self.saved_at = datetime.utcnow()
 
     @classmethod
     def exists_for(cls, user, article):

--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -521,15 +521,16 @@ class UserArticle(db.Model):
         # specific article id, so a save against the original wouldn't be
         # detected when the simplified version is what's served. Check the
         # parent too so saved-status survives the version swap.
-        has_pc = PersonalCopy.exists_for(user, article)
-        if not has_pc and article.parent_article_id:
-            has_pc = (
-                PersonalCopy.query.filter_by(
-                    user_id=user.id, article_id=article.parent_article_id
-                ).first()
-                is not None
-            )
-        returned_info["has_personal_copy"] = bool(has_pc)
+        pc = PersonalCopy.query.filter_by(
+            user_id=user.id, article_id=article.id
+        ).first()
+        if not pc and article.parent_article_id:
+            pc = PersonalCopy.query.filter_by(
+                user_id=user.id, article_id=article.parent_article_id
+            ).first()
+        returned_info["has_personal_copy"] = pc is not None
+        if pc is not None and pc.saved_at is not None:
+            returned_info["personal_copy_saved_at"] = datetime_to_json(pc.saved_at)
 
         # If this is an original article and the user has already saved a
         # simplified child of it (auto-saved when they tap Simplify), expose


### PR DESCRIPTION
## Summary

- Adds `saved_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP` to `personal_copy`, with existing rows backfilled from `article.published_time` (best available proxy for when the user saved).
- `user_article_info` now exposes `personal_copy_saved_at` whenever the user has a PC for the article (or its parent, so the original→simplified swap doesn't drop the field).
- Switches the PC presence-check from `exists_for()` (count) to `.first()` (row) so `saved_at` comes back without an extra query.

Motivation: My Articles is sorted by save-recency but currently displays publish time, which is misleading. The companion frontend PR (zeeguu/web) renders "Saved Xh ago" on that surface.

**Note on sort key.** `PersonalCopy.all_for` / `get_page_for` still order by `desc(PersonalCopy.id)`, not by `saved_at`. The id (autoincrement) is the true save-insertion order for legacy rows; the backfill maps `saved_at` to article publish time, which would scramble existing users' My Articles lists if used as the sort key. `saved_at` is for display only.

## Test plan

- [ ] Apply `tools/migrations/26-05-20--add_personal_copy_saved_at.sql` locally; verify the column exists and existing rows have non-NULL backfilled values.
- [ ] Save a new article in the app; row should land with `saved_at ≈ NOW()`.
- [ ] `/user_articles/recommended` response for an already-saved article includes `personal_copy_saved_at`.
- [ ] My Articles endpoint response includes the field.
- [ ] Original→simplified swap case: `personal_copy_saved_at` populated when the user saved the original and is now served the simplified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)