### PR TITLE
My Articles: paginate /user_articles/my_articles

### DIFF
--- a/zeeguu/api/endpoints/user_articles.py
+++ b/zeeguu/api/endpoints/user_articles.py
@@ -239,15 +239,21 @@ def user_articles_starred_and_liked():
 
 # ---------------------------------------------------------------------------
 @api.route("/user_articles/my_articles", methods=("GET",))
+@api.route("/user_articles/my_articles/<int:count>", methods=("GET",))
+@api.route("/user_articles/my_articles/<int:count>/<int:page>", methods=("GET",))
 # ---------------------------------------------------------------------------
 @cross_domain
 @requires_session
-def user_articles_my_articles():
+def user_articles_my_articles(count: int = None, page: int = 0):
     """My Articles = the user's saves (PersonalCopy). Distinct from
     /user_articles/starred_or_liked, which keys off UserArticle rows and
-    misses saves the user hasn't opened yet."""
+    misses saves the user hasn't opened yet.
+
+    Paginated when count is provided — sort + family-collapse happens over
+    all saves first, then the slice is fed through article_infos (which
+    tokenizes / fills caches and is the expensive bit)."""
     user = User.find_by_id(flask.g.user_id)
-    return json_result(UserArticle.my_articles_info(user))
+    return json_result(UserArticle.my_articles_info(user, count=count, page=page))
 
 
 # ---------------------------------------------------------------------------

--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -288,7 +288,7 @@ class UserArticle(db.Model):
         return cls.article_infos(user, articles, select_appropriate=False)
 
     @classmethod
-    def my_articles_info(cls, user):
+    def my_articles_info(cls, user, count=None, page=0):
         """Articles the user has explicitly saved (PersonalCopy).
 
         Skips the UserArticle table entirely: a save (Simplify / Send to
@@ -298,6 +298,11 @@ class UserArticle(db.Model):
 
         Family-collapsed (one card per parent_article_id family, most
         recently saved sibling wins) and sorted by save time descending.
+
+        When `count` is provided, the sorted+collapsed list is sliced to
+        the requested page before article_infos runs — article_infos is
+        the expensive step (tokenization caches per article), and a user
+        with hundreds of saves would otherwise pay it on every load.
         """
         saved_articles = PersonalCopy.all_for(user)
         if not saved_articles:
@@ -346,6 +351,9 @@ class UserArticle(db.Model):
             best_by_family.values(), key=lambda x: x[1], reverse=True
         )
         articles = [a for a, _ in sorted_articles]
+
+        if count is not None:
+            articles = articles[page * count : (page + 1) * count]
 
         return cls.article_infos(user, articles, select_appropriate=False)
 


### PR DESCRIPTION
## Summary

A user with hundreds of saves was paying `article_infos` cost for every single one on every My Articles load — that's the tokenization-cache + serialize step, which dominates the response time. Sort + family-collapse runs over all saves first (cheap), then the slice is fed through `article_infos`, so we pay only for the page being rendered.

- Adds `/<count>` and `/<count>/<page>` route variants on `/user_articles/my_articles`, mirroring `/user_articles/recommended`.
- The no-args variant keeps the old return-everything behavior for any legacy caller.
- Companion frontend PR (zeeguu/web#1127) consumes `/my_articles/20/<page>` via `useArticlePagination`.

## Test plan

- [ ] `GET /user_articles/my_articles` (no args) still returns the full list (legacy path).
- [ ] `GET /user_articles/my_articles/20/0` returns up to 20 items, most-recently-saved first.
- [ ] `GET /user_articles/my_articles/20/1` returns the next 20 (no overlap with page 0).
- [ ] Page past the end returns `[]` (no error).
- [ ] Sort + family-collapse semantics unchanged: same items in the same order as before, just sliced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)