### PR TITLE
Add deprecated_at flag to gate audio-lesson script reuse

### DIFF
--- a/tools/deprecate_ambiguous_meaning_lessons.py
+++ b/tools/deprecate_ambiguous_meaning_lessons.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""
+Mark meaning-lesson scripts containing the ambiguous "(how|could) you say
+you ..." challenge phrasing as deprecated, so future daily audio lessons
+regenerate them under the new prompt that pins listener-as-speaker.
+
+Existing daily_audio_lesson_segment rows that already reference these
+audio_lesson_meaning rows keep playing as before — the cached MP3s stay
+on disk; only fresh lookups via AudioLessonMeaning.find() skip them.
+
+Usage:
+    python -m tools.deprecate_ambiguous_meaning_lessons          # dry run
+    python -m tools.deprecate_ambiguous_meaning_lessons --apply  # do it
+"""
+
+import os
+import sys
+import argparse
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from zeeguu.api.app import create_app_for_scripts
+from zeeguu.core.model import db
+
+app = create_app_for_scripts()
+app.app_context().push()
+
+from sqlalchemy import text
+
+
+AMBIGUOUS_REGEX = r"(how|could) you say you[' ]?(re| are| ll| ve)"
+
+
+def main(apply: bool):
+    matched = db.session.execute(
+        text(
+            "SELECT COUNT(*) FROM audio_lesson_meaning "
+            "WHERE deprecated_at IS NULL AND script REGEXP :pattern"
+        ),
+        {"pattern": AMBIGUOUS_REGEX},
+    ).scalar()
+
+    print(f"Matched {matched} non-deprecated rows with ambiguous challenge phrasing.")
+
+    if not apply:
+        print("Dry run — no rows updated. Re-run with --apply to mark them deprecated.")
+        return
+
+    if matched == 0:
+        print("Nothing to do.")
+        return
+
+    result = db.session.execute(
+        text(
+            "UPDATE audio_lesson_meaning SET deprecated_at = NOW() "
+            "WHERE deprecated_at IS NULL AND script REGEXP :pattern"
+        ),
+        {"pattern": AMBIGUOUS_REGEX},
+    )
+    db.session.commit()
+    print(f"Marked {result.rowcount} rows deprecated.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually mark rows deprecated. Without this flag the script only reports counts.",
+    )
+    args = parser.parse_args()
+    main(apply=args.apply)

--- a/tools/migrations/26-05-22--add_deprecated_at_audio_lesson_segments.sql
+++ b/tools/migrations/26-05-22--add_deprecated_at_audio_lesson_segments.sql
@@ -1,0 +1,16 @@
+-- Add a deprecation flag to cached audio lesson scripts so we can stop
+-- recycling specific scripts into newly generated daily audio lessons
+-- (e.g. ones produced under an earlier, ambiguous prompt template).
+--
+-- Forward-only gate: existing daily_audio_lesson_segment rows that reference
+-- a deprecated audio_lesson_meaning / audio_lesson_dialogue keep playing as
+-- before. Only future lookups via .find() / .find_unheard() skip them and
+-- fall through to fresh generation.
+
+ALTER TABLE audio_lesson_meaning
+    ADD COLUMN deprecated_at TIMESTAMP NULL DEFAULT NULL
+        COMMENT 'When set, lookup helpers skip this row and force regeneration.';
+
+ALTER TABLE audio_lesson_dialogue
+    ADD COLUMN deprecated_at TIMESTAMP NULL DEFAULT NULL
+        COMMENT 'When set, lookup helpers skip this row and force regeneration.';

--- a/zeeguu/core/model/audio_lesson_dialogue.py
+++ b/zeeguu/core/model/audio_lesson_dialogue.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, JSON, Enum, ForeignKey
+from sqlalchemy import Column, Integer, String, Text, JSON, Enum, ForeignKey, DateTime
 from sqlalchemy.orm import relationship
 
 from zeeguu.core.model.db import db
@@ -36,6 +36,10 @@ class AudioLessonDialogue(db.Model):
     duration_seconds = Column(Integer)
     is_general = Column(db.Boolean, default=False)
     created_by = Column(String(255), nullable=False)
+
+    # When set, cache lookups skip this row and force regeneration. Existing
+    # daily lesson segments that already reference it keep playing as before.
+    deprecated_at = Column(DateTime, nullable=True)
 
     def __init__(
         self,
@@ -112,7 +116,8 @@ class AudioLessonDialogue(db.Model):
             teacher_language_id=teacher_language.id,
             difficulty_level=difficulty_level,
         ).filter(
-            cls.id.notin_(heard_ids)
+            cls.id.notin_(heard_ids),
+            cls.deprecated_at.is_(None),
         )
 
         if only_general:

--- a/zeeguu/core/model/audio_lesson_meaning.py
+++ b/zeeguu/core/model/audio_lesson_meaning.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, JSON, Enum, ForeignKey
+from sqlalchemy import Column, Integer, String, Text, JSON, Enum, ForeignKey, DateTime
 from sqlalchemy.orm import relationship
 
 from zeeguu.core.model.db import db
@@ -34,6 +34,10 @@ class AudioLessonMeaning(db.Model):
     duration_seconds = Column(Integer)
     created_by = Column(String(255), nullable=False)  # e.g. Claude-v2-Opus-Promopt1
 
+    # When set, cache lookups skip this row and force regeneration. Existing
+    # daily lesson segments that already reference it keep playing as before.
+    deprecated_at = Column(DateTime, nullable=True)
+
     def __init__(
         self,
         meaning,
@@ -64,8 +68,8 @@ class AudioLessonMeaning(db.Model):
 
     @classmethod
     def find(cls, meaning, teacher_language=None):
-        """Find audio lesson for a specific meaning and teacher language."""
-        query = cls.query.filter_by(meaning=meaning)
+        """Find a non-deprecated audio lesson for a specific meaning and teacher language."""
+        query = cls.query.filter_by(meaning=meaning).filter(cls.deprecated_at.is_(None))
         if teacher_language:
             query = query.filter_by(teacher_language_id=teacher_language.id)
         return query.first()


### PR DESCRIPTION
## Summary
- Adds nullable `deprecated_at TIMESTAMP` to `audio_lesson_meaning` and `audio_lesson_dialogue`.
- `AudioLessonMeaning.find()` and `AudioLessonDialogue.find_unheard()` now skip deprecated rows, so the next time a daily lesson needs that meaning/dialogue it regenerates under the current prompt.
- Existing `daily_audio_lesson_segment` rows that already reference a deprecated row keep playing — the cached MP3s stay on disk; deprecation is forward-only and only affects *new* lookups.
- Ships `tools/deprecate_ambiguous_meaning_lessons.py` to flag the ~1,035 meaning lessons whose teacher challenges were generated under the previous prompt ("how would you say you're..." / "could you say you..."). The new prompt (already deployed on master) requires explicit subject + addressee, so those scripts are sub-par and we want them out of the reuse pool.

## Why two tables
Same cache-and-reuse pattern lives in both `audio_lesson_meaning` (one row per word/meaning + teacher language) and `audio_lesson_dialogue` (one row per situation/topic + teacher language + difficulty). Both need a flag for the same reason — the prompt change applies to both lesson kinds.

## Known wrinkle (not blocking)
Audio file paths are keyed on `meaning_id`, not on the `audio_lesson_meaning.id` row. So if a meaning's row is deprecated and a new one generated, the new audio overwrites the same file on disk. Existing daily lessons that reference the *old* row will, on next playback, hear the *new* audio while their transcript field still shows the old script. That's the existing design — flagged here for awareness; not introduced by this PR.

## Backfill workflow
1. Merge + deploy this PR (schema + filter live).
2. Run `python -m tools.deprecate_ambiguous_meaning_lessons` on prod (dry-run by default) to confirm the count matches ~1,035.
3. Re-run with `--apply` to commit.

## Test plan
- [ ] Migration applies cleanly on staging.
- [ ] `AudioLessonMeaning.find()` returns `None` for a manually deprecated row, `Some(row)` for a non-deprecated row with the same meaning.
- [ ] `AudioLessonDialogue.find_unheard()` ditto.
- [ ] Generate a daily lesson where one of the requested meanings has only a deprecated cached row — confirm a fresh row is generated.
- [ ] Run the backfill tool with `--apply` on staging; confirm the rowcount matches the dry-run count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)