### PR TITLE
Shareable audio lessons: UUID-based public links

### DIFF
--- a/tools/migrations/26-05-22-b--add_share_uuid_to_daily_audio_lesson.sql
+++ b/tools/migrations/26-05-22-b--add_share_uuid_to_daily_audio_lesson.sql
@@ -1,0 +1,3 @@
+ALTER TABLE daily_audio_lesson
+ADD COLUMN share_uuid VARCHAR(36) DEFAULT NULL,
+ADD UNIQUE INDEX idx_daily_audio_lesson_share_uuid (share_uuid);

--- a/zeeguu/api/endpoints/audio_lessons.py
+++ b/zeeguu/api/endpoints/audio_lessons.py
@@ -6,7 +6,7 @@ from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
 from zeeguu.core.audio_lessons.daily_lesson_generator import DailyLessonGenerator
 from zeeguu.core.audio_lessons.script_generator import VALID_LESSON_TYPES, THREE_WORDS_LESSON
 from zeeguu.core.audio_lessons.suggestion_validator import validate_suggestion
-from zeeguu.core.model import db, User, UserWord, AudioLessonGenerationProgress
+from zeeguu.core.model import db, User, UserWord, AudioLessonGenerationProgress, DailyAudioLesson
 from zeeguu.logging import log
 from . import api
 
@@ -159,19 +159,36 @@ def get_daily_lesson():
     return json_result(result), status_code
 
 
-@api.route("/shared_audio_lesson/<int:lesson_id>", methods=["GET"])
+@api.route("/shared_audio_lesson/<string:share_uuid>", methods=["GET"])
 @cross_domain
-def get_shared_audio_lesson(lesson_id):
+def get_shared_audio_lesson(share_uuid):
     """
-    Read-only public view of an audio lesson for share links. Returns the
-    lesson metadata + audio URL, but no owner-specific state (pause position,
-    completion, listen count) and no UserWord data. No session required —
-    matches the static audio file's accessibility.
+    Read-only public view of an audio lesson for share links. Looked up by
+    share_uuid so integer lesson IDs can't be enumerated. Returns lesson
+    metadata + audio URL, but no owner-specific state (pause position,
+    completion, listen count) and no UserWord data. No session required.
     """
     generator = DailyLessonGenerator()
-    result = generator.get_shared_lesson_view(lesson_id)
+    result = generator.get_shared_lesson_view(share_uuid)
     status_code = result.pop("status_code", 200)
     return json_result(result), status_code
+
+
+@api.route("/create_lesson_share_link/<int:lesson_id>", methods=["POST"])
+@cross_domain
+@requires_session
+def create_lesson_share_link(lesson_id):
+    """
+    Owner-only: mint (or return existing) share_uuid for this lesson.
+    Returns {"share_uuid": "..."} for the frontend to build the share URL.
+    """
+    lesson = DailyAudioLesson.query.filter_by(id=lesson_id, user_id=flask.g.user_id).first()
+    if not lesson:
+        return json_result({"error": "Lesson not found"}), 404
+
+    lesson.ensure_share_uuid()
+    db.session.commit()
+    return json_result({"share_uuid": lesson.share_uuid})
 
 
 @api.route("/get_todays_lesson", methods=["GET"])

--- a/zeeguu/api/endpoints/audio_lessons.py
+++ b/zeeguu/api/endpoints/audio_lessons.py
@@ -162,14 +162,9 @@ def get_daily_lesson():
 @api.route("/shared_audio_lesson/<string:share_uuid>", methods=["GET"])
 @cross_domain
 def get_shared_audio_lesson(share_uuid):
-    """
-    Read-only public view of an audio lesson for share links. Looked up by
-    share_uuid so integer lesson IDs can't be enumerated. Returns lesson
-    metadata + audio URL, but no owner-specific state (pause position,
-    completion, listen count) and no UserWord data. No session required.
-    """
-    generator = DailyLessonGenerator()
-    result = generator.get_shared_lesson_view(share_uuid)
+    """Public read-only view of a shared lesson. Keyed on share_uuid so
+    integer lesson IDs can't be enumerated."""
+    result = DailyLessonGenerator().get_shared_lesson_view(share_uuid)
     status_code = result.pop("status_code", 200)
     return json_result(result), status_code
 
@@ -178,10 +173,7 @@ def get_shared_audio_lesson(share_uuid):
 @cross_domain
 @requires_session
 def create_lesson_share_link(lesson_id):
-    """
-    Owner-only: mint (or return existing) share_uuid for this lesson.
-    Returns {"share_uuid": "..."} for the frontend to build the share URL.
-    """
+    """Owner-only: mint (or return existing) share_uuid for this lesson."""
     lesson = DailyAudioLesson.query.filter_by(id=lesson_id, user_id=flask.g.user_id).first()
     if not lesson:
         return json_result({"error": "Lesson not found"}), 404

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -617,10 +617,7 @@ class DailyLessonGenerator:
     def get_shared_lesson_view(self, share_uuid):
         """Public-safe view for share links: no owner playback state, no UserWord rows.
         Looked up by share_uuid (not integer id) to prevent enumeration."""
-        if not share_uuid or not isinstance(share_uuid, str):
-            return {"error": "Invalid share token", "status_code": 400}
-
-        lesson = DailyAudioLesson.find_by_share_uuid(share_uuid)
+        lesson = DailyAudioLesson.query.filter_by(share_uuid=share_uuid).first()
         if not lesson:
             return {"error": "Lesson not found", "status_code": 404}
         if not os.path.exists(self._audio_path(lesson)):

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -614,14 +614,13 @@ class DailyLessonGenerator:
             "title": lesson.display_title(),
         }
 
-    def get_shared_lesson_view(self, lesson_id):
-        """Public-safe view for share links: no owner playback state, no UserWord rows."""
-        try:
-            lesson_id = int(lesson_id)
-        except (TypeError, ValueError):
-            return {"error": "Invalid lesson_id parameter", "status_code": 400}
+    def get_shared_lesson_view(self, share_uuid):
+        """Public-safe view for share links: no owner playback state, no UserWord rows.
+        Looked up by share_uuid (not integer id) to prevent enumeration."""
+        if not share_uuid or not isinstance(share_uuid, str):
+            return {"error": "Invalid share token", "status_code": 400}
 
-        lesson = DailyAudioLesson.query.filter_by(id=lesson_id).first()
+        lesson = DailyAudioLesson.find_by_share_uuid(share_uuid)
         if not lesson:
             return {"error": "Lesson not found", "status_code": 404}
         if not os.path.exists(self._audio_path(lesson)):

--- a/zeeguu/core/model/daily_audio_lesson.py
+++ b/zeeguu/core/model/daily_audio_lesson.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 from sqlalchemy import Column, Integer, JSON, ForeignKey, TIMESTAMP
 from sqlalchemy.orm import relationship
@@ -43,6 +44,10 @@ class DailyAudioLesson(db.Model):
     raw_suggestion = Column(db.String(100), nullable=True)
     canonical_suggestion = Column(db.String(100), nullable=True)
     lesson_type = Column(db.String(20), nullable=True)
+
+    # Unguessable token used in public share links. NULL until the owner first
+    # generates a share link — lazily minted so we don't pay for unused UUIDs.
+    share_uuid = Column(db.String(36), unique=True, nullable=True)
 
     # Relationship to segments (individual meaning lessons)
     segments = relationship(
@@ -182,6 +187,17 @@ class DailyAudioLesson(db.Model):
             if segment.segment_type == "meaning_lesson" and segment.audio_lesson_meaning
         ]
         return ", ".join(origins) if origins else None
+
+    def ensure_share_uuid(self):
+        """Lazily mint and persist a share token. Idempotent — returns the
+        existing token if already set."""
+        if not self.share_uuid:
+            self.share_uuid = str(uuid.uuid4())
+        return self.share_uuid
+
+    @classmethod
+    def find_by_share_uuid(cls, share_uuid):
+        return cls.query.filter_by(share_uuid=share_uuid).first()
 
     @classmethod
     def find_canonical_for_raw_suggestion(cls, user, raw_suggestion):

--- a/zeeguu/core/model/daily_audio_lesson.py
+++ b/zeeguu/core/model/daily_audio_lesson.py
@@ -45,8 +45,7 @@ class DailyAudioLesson(db.Model):
     canonical_suggestion = Column(db.String(100), nullable=True)
     lesson_type = Column(db.String(20), nullable=True)
 
-    # Unguessable token used in public share links. NULL until the owner first
-    # generates a share link — lazily minted so we don't pay for unused UUIDs.
+    # NULL until the owner first generates a share link.
     share_uuid = Column(db.String(36), unique=True, nullable=True)
 
     # Relationship to segments (individual meaning lessons)
@@ -189,15 +188,9 @@ class DailyAudioLesson(db.Model):
         return ", ".join(origins) if origins else None
 
     def ensure_share_uuid(self):
-        """Lazily mint and persist a share token. Idempotent — returns the
-        existing token if already set."""
         if not self.share_uuid:
             self.share_uuid = str(uuid.uuid4())
         return self.share_uuid
-
-    @classmethod
-    def find_by_share_uuid(cls, share_uuid):
-        return cls.query.filter_by(share_uuid=share_uuid).first()
 
     @classmethod
     def find_canonical_for_raw_suggestion(cls, user, raw_suggestion):


### PR DESCRIPTION
## Summary
- Adds an unguessable `share_uuid` to `daily_audio_lesson`, minted lazily by the owner via a new `POST /create_lesson_share_link/<lesson_id>` endpoint.
- The public read endpoint now keys on `share_uuid` instead of the integer lesson ID — so the previous `/shared_audio_lesson/1`, `/2`, `/3`... enumeration path no longer works.
- Companion web PR: zeeguu/web#feat/shareable-audio-lesson-uuid (renders the public landing page with install CTA).

## Why
Today the share endpoint accepts the auto-increment integer ID, which means anyone with the URL pattern can walk the whole lesson catalogue. We want to share lessons with friends who don't have an account — a UUID-based token is the minimum bar for that.

## Migration
\`tools/migrations/26-05-22-b--add_share_uuid_to_daily_audio_lesson.sql\` — adds a nullable, unique `share_uuid VARCHAR(36)`. No backfill; the column stays NULL until each lesson is first shared.

## Test plan
- [ ] Run migration locally
- [ ] Existing share button (web) mints a UUID and forms the new URL
- [ ] `GET /shared_audio_lesson/<uuid>` returns lesson; with a guessed integer or random string returns 404
- [ ] `POST /create_lesson_share_link/<lesson_id>` is idempotent and 404s for non-owners

🤖 Generated with [Claude Code](https://claude.com/claude-code)