### PR TITLE
ADR 022: return alternatives from /get_one_translation; add /ask_llm_translation

### DIFF
--- a/zeeguu/api/endpoints/translation.py
+++ b/zeeguu/api/endpoints/translation.py
@@ -176,9 +176,13 @@ def get_one_translation(from_lang_code, to_lang_code):
         "source": t1["source"],
         "likelihood": t1["likelihood"],
     }
-    # Optional disagreement markers from the 3-way parallel voter
-    # (translate_in_context). The frontend uses these to surface alternative
-    # provider opinions inline / auto-open the alternatives menu.
+    # ADR 022: the 3-way voter attaches the full deduped, vote-ordered list
+    # of provider results. Clients render the alternatives menu directly from
+    # this — no second round of SSE calls needed for the menu's stable rows.
+    if t1.get("alternatives"):
+        response_payload["alternatives"] = t1["alternatives"]
+    # Legacy fields kept during ADR 022's deprecation window; clients should
+    # migrate to `alternatives` and stop reading these.
     if t1.get("competing_translations"):
         response_payload["competing_translations"] = t1["competing_translations"]
     if t1.get("disagreement"):
@@ -306,6 +310,39 @@ def get_translations_stream(from_lang_code, to_lang_code):
             'X-Accel-Buffering': 'no',  # Disable nginx buffering
         }
     )
+
+
+@api.route("/ask_llm_translation/<from_lang_code>/<to_lang_code>", methods=["POST"])
+@cross_domain
+@requires_session
+def ask_llm_translation(from_lang_code, to_lang_code):
+    """
+    ADR 022: explicit on-demand LLM translation.
+
+    The LLM is the most expensive translator in the bag, and the streaming
+    menu (`/get_translations_stream`) used to call it on every menu open even
+    though the result was rarely consulted. This endpoint moves the LLM call
+    behind a user-initiated "Ask LLM" button in the reader's alternatives
+    menu, so the cost is paid only when a learner explicitly asks for it.
+
+    Request body: ``{ "word": str, "context": str }``
+    Response: ``{ "translation": str, "source": "LLM" }`` or 404 on failure.
+    """
+    from zeeguu.core.translation_services.translator import translate_with_llm
+
+    word_str = request.json.get("word", "").strip(punctuation_extended)
+    context = request.json.get("context", "").strip()
+    if not word_str:
+        return "word required", 400
+
+    result = translate_with_llm(word_str, context, from_lang_code, to_lang_code)
+    if not result:
+        return "LLM translation failed", 404
+
+    return json_result({
+        "translation": result["translation"],
+        "source": result.get("source", "LLM"),
+    })
 
 
 @api.route("/update_bookmark_translation/<bookmark_id>", methods=["POST"])

--- a/zeeguu/api/endpoints/translation.py
+++ b/zeeguu/api/endpoints/translation.py
@@ -30,12 +30,17 @@ punctuation_extended = "»«" + punctuation
 IS_DEV_SKIP_TRANSLATION = int(os.environ.get("DEV_SKIP_TRANSLATION", 0)) == 1
 
 
+# ADR 022: canonical route is /translate_word — the response now carries the
+# 3-way voter's full `alternatives` list, so the legacy "one translation"
+# framing is misleading. The old /get_one_translation path is kept as an
+# alias for one release so the frozen extension bundle keeps working.
+@api.route("/translate_word/<from_lang_code>/<to_lang_code>", methods=["POST"])
 @api.route("/get_one_translation/<from_lang_code>/<to_lang_code>", methods=["POST"])
 @cross_domain
 @requires_session
-def get_one_translation(from_lang_code, to_lang_code):
+def translate_word(from_lang_code, to_lang_code):
     zeeguu_log(
-        f"[TRANSLATION-ENTRY-IMMEDIATE] ENTERED get_one_translation function: from={from_lang_code}, to={to_lang_code}"
+        f"[TRANSLATION-ENTRY-IMMEDIATE] ENTERED translate_word function: from={from_lang_code}, to={to_lang_code}"
     )
     """
     :return: json array with translations
@@ -43,7 +48,7 @@ def get_one_translation(from_lang_code, to_lang_code):
     from zeeguu.logging import log
 
     log(
-        f"[TRANSLATION-ENTRY] get_one_translation CALLED: from={from_lang_code}, to={to_lang_code}, user={flask.g.user_id}"
+        f"[TRANSLATION-ENTRY] translate_word CALLED: from={from_lang_code}, to={to_lang_code}, user={flask.g.user_id}"
     )
 
     word_str = request.json["word"].strip(punctuation_extended)

--- a/zeeguu/api/test/test_bookmark_positions.py
+++ b/zeeguu/api/test/test_bookmark_positions.py
@@ -30,7 +30,7 @@ def _create_bookmark_with_positions(client, word, context, sentence_i=0, token_i
 
     # Create bookmark via translation endpoint
     response = client.post(
-        "/get_one_translation/de/en",
+        "/translate_word/de/en",
         json={
             "word": word,
             "context": context,
@@ -457,7 +457,7 @@ def test_word_expansion_workflow(client):
 
     # Step 1: User translates "nicht" (single word at position 2)
     response1 = client.post(
-        "/get_one_translation/de/en",
+        "/translate_word/de/en",
         json={
             "word": "nicht",
             "context": context_text,
@@ -485,7 +485,7 @@ def test_word_expansion_workflow(client):
     # doesn't handle empty responses well, so we'll just verify the new one works
 
     response2 = client.post(
-        "/get_one_translation/de/en",
+        "/translate_word/de/en",
         json={
             "word": "nicht mehr",
             "context": context_text,

--- a/zeeguu/core/test/test_translation_voter_alternatives.py
+++ b/zeeguu/core/test/test_translation_voter_alternatives.py
@@ -1,0 +1,144 @@
+"""ADR 022: ``_vote_single_word_translation`` attaches an ``alternatives``
+list to its return dict so the frontend can render the alternatives menu
+directly, without a second round of provider calls.
+
+These tests pin the shape (deduped, vote-ordered, winner first) across the
+four return paths: no provider succeeded, single provider succeeded, all
+providers agreed, providers disagreed.
+"""
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from zeeguu.core.translation_services import translator
+
+
+def _provider_result(translation, source):
+    """Render the minimal result dict the voter accepts from a provider."""
+    return {"translation": translation, "source": source, "likelihood": 90}
+
+
+class VoterAlternativesTest(TestCase):
+
+    def setUp(self):
+        self.data = {
+            "source_language": "da",
+            "target_language": "en",
+            "word": "tæt",
+            "query": None,
+            "context": "Han stod tæt på vinduet.",
+        }
+
+    @patch.object(translator, "deepl_contextual_translate_cached")
+    @patch.object(translator, "google_contextual_translate")
+    @patch.object(translator, "azure_alignment_contextual_translate")
+    @patch.object(translator, "microsoft_contextual_translate")
+    def test_all_three_agree(self, ms, azure, google, deepl):
+        azure.return_value = _provider_result("close", "Azure - alignment")
+        google.return_value = _provider_result("close", "Google - with context")
+        deepl.return_value = _provider_result("close", "DeepL - with context")
+        ms.return_value = None  # fallback, must not be consulted
+
+        result = translator._vote_single_word_translation(self.data)
+
+        self.assertEqual(result["translation"], "close")
+        self.assertEqual(result["alternatives"], [
+            {"translation": "close", "source": "Google - with context", "votes": 3},
+        ])
+        # Legacy fields: no disagreement, no competing.
+        self.assertNotIn("competing_translations", result)
+        self.assertNotIn("disagreement", result)
+
+    @patch.object(translator, "deepl_contextual_translate_cached")
+    @patch.object(translator, "google_contextual_translate")
+    @patch.object(translator, "azure_alignment_contextual_translate")
+    @patch.object(translator, "microsoft_contextual_translate")
+    def test_two_vs_one_splits_into_two_alternatives(self, ms, azure, google, deepl):
+        azure.return_value = _provider_result("close", "Azure - alignment")
+        google.return_value = _provider_result("close", "Google - with context")
+        deepl.return_value = _provider_result("tight", "DeepL - with context")
+        ms.return_value = None
+
+        result = translator._vote_single_word_translation(self.data)
+
+        # Winner is the 2-vote bucket; loser bucket follows.
+        self.assertEqual(result["translation"], "close")
+        self.assertEqual(result["alternatives"], [
+            {"translation": "close", "source": "Google - with context", "votes": 2},
+            {"translation": "tight", "source": "DeepL - with context", "votes": 1},
+        ])
+        # Legacy fields still present during deprecation window.
+        self.assertEqual(result["competing_translations"], [
+            {"translation": "tight", "source": "DeepL - with context"},
+        ])
+        self.assertNotIn("disagreement", result)
+
+    @patch.object(translator, "deepl_contextual_translate_cached")
+    @patch.object(translator, "google_contextual_translate")
+    @patch.object(translator, "azure_alignment_contextual_translate")
+    @patch.object(translator, "microsoft_contextual_translate")
+    def test_three_way_split_flags_disagreement(self, ms, azure, google, deepl):
+        azure.return_value = _provider_result("close", "Azure - alignment")
+        google.return_value = _provider_result("tight", "Google - with context")
+        deepl.return_value = _provider_result("near", "DeepL - with context")
+        ms.return_value = None
+
+        result = translator._vote_single_word_translation(self.data)
+
+        # All three buckets are size 1; provider preference (Google > DeepL >
+        # Azure) breaks the tie, so Google's "tight" wins.
+        self.assertEqual(result["translation"], "tight")
+        self.assertEqual([alt["votes"] for alt in result["alternatives"]], [1, 1, 1])
+        self.assertEqual(
+            {alt["translation"] for alt in result["alternatives"]},
+            {"tight", "near", "close"},
+        )
+        self.assertTrue(result["disagreement"])
+
+    @patch.object(translator, "deepl_contextual_translate_cached")
+    @patch.object(translator, "google_contextual_translate")
+    @patch.object(translator, "azure_alignment_contextual_translate")
+    @patch.object(translator, "microsoft_contextual_translate")
+    def test_only_one_provider_succeeded(self, ms, azure, google, deepl):
+        azure.return_value = None
+        google.return_value = _provider_result("close", "Google - with context")
+        deepl.return_value = None
+        ms.return_value = None
+
+        result = translator._vote_single_word_translation(self.data)
+
+        self.assertEqual(result["translation"], "close")
+        self.assertEqual(result["alternatives"], [
+            {"translation": "close", "source": "Google - with context", "votes": 1},
+        ])
+
+    @patch.object(translator, "deepl_contextual_translate_cached")
+    @patch.object(translator, "google_contextual_translate")
+    @patch.object(translator, "azure_alignment_contextual_translate")
+    @patch.object(translator, "microsoft_contextual_translate")
+    def test_all_three_fail_falls_back_to_microsoft_with_alternatives(self, ms, azure, google, deepl):
+        azure.return_value = None
+        google.return_value = None
+        deepl.return_value = None
+        ms.return_value = _provider_result("close", "Microsoft - with context")
+
+        result = translator._vote_single_word_translation(self.data)
+
+        self.assertEqual(result["translation"], "close")
+        self.assertEqual(result["alternatives"], [
+            {"translation": "close", "source": "Microsoft - with context", "votes": 1},
+        ])
+
+    @patch.object(translator, "deepl_contextual_translate_cached")
+    @patch.object(translator, "google_contextual_translate")
+    @patch.object(translator, "azure_alignment_contextual_translate")
+    @patch.object(translator, "microsoft_contextual_translate")
+    def test_all_fail_including_fallback_returns_none(self, ms, azure, google, deepl):
+        azure.return_value = None
+        google.return_value = None
+        deepl.return_value = None
+        ms.return_value = None
+
+        result = translator._vote_single_word_translation(self.data)
+
+        self.assertIsNone(result)

--- a/zeeguu/core/translation_services/translator.py
+++ b/zeeguu/core/translation_services/translator.py
@@ -351,18 +351,31 @@ def _translation_key(text):
 _PROVIDER_PREFERENCE = {"google": 0, "deepl": 1, "azure": 2}
 
 
+def _alternative_entry(result_dict, votes):
+    """Render a provider result as an ``alternatives`` list entry."""
+    return {
+        "translation": result_dict["translation"],
+        "source": result_dict.get("source", result_dict.get("service_name", "unknown")),
+        "votes": votes,
+    }
+
+
 def _vote_single_word_translation(data):
     """
     Run Azure alignment, Google contextual, and DeepL contextual in parallel
     and pick a primary translation by majority-of-3 voting.
 
-    Returns the chosen result dict with two extra optional keys:
-      - ``competing_translations``: list of {translation, source} when the
-        primary doesn't have unanimous support, so the UI can surface what
-        the other providers said.
+    Returns the chosen result dict with three extra optional keys:
+      - ``alternatives``: list of {translation, source, votes} for every
+        unique provider result, winner first, sorted by votes desc then by
+        provider preference. Always populated when at least one provider
+        succeeded. See ADR 022 — clients render the menu directly from this.
+      - ``competing_translations``: legacy subset of ``alternatives`` that
+        excludes the winner and is only present when more than one bucket
+        existed. Kept during ADR 022's deprecation window.
       - ``disagreement``: True when no majority emerged (all 3 distinct, or
-        only 2 of 3 succeeded and they disagreed). The frontend keys on this
-        to auto-open the alternatives menu.
+        only 2 of 3 succeeded and they disagreed). Kept during ADR 022's
+        deprecation window; derivable from ``alternatives[0]["votes"] < 2``.
 
     Falls back to Microsoft contextual if all three contextual providers fail.
     """
@@ -393,10 +406,16 @@ def _vote_single_word_translation(data):
     succeeded = [(name, r) for name, r in results.items() if r and r.get("translation")]
 
     if not succeeded:
-        return microsoft_contextual_translate(data)
+        fallback = microsoft_contextual_translate(data)
+        if fallback:
+            fallback = dict(fallback)
+            fallback["alternatives"] = [_alternative_entry(fallback, 1)]
+        return fallback
 
     if len(succeeded) == 1:
-        return succeeded[0][1]
+        winner = dict(succeeded[0][1])
+        winner["alternatives"] = [_alternative_entry(winner, 1)]
+        return winner
 
     buckets = {}
     for name, r in succeeded:
@@ -407,7 +426,9 @@ def _vote_single_word_translation(data):
         return min(entries, key=lambda e: _PROVIDER_PREFERENCE[e[0]])[1]
 
     if len(buckets) == 1:
-        return pick_representative(succeeded)
+        winner = dict(pick_representative(succeeded))
+        winner["alternatives"] = [_alternative_entry(winner, len(succeeded))]
+        return winner
 
     # (representative_dict, vote_count) per bucket, sorted by votes desc then
     # by representative provider's preference.
@@ -423,6 +444,7 @@ def _vote_single_word_translation(data):
     ]
 
     winner = dict(winner_dict)
+    winner["alternatives"] = [_alternative_entry(rep, votes) for rep, votes in bucket_picks]
     winner["competing_translations"] = competing
     if winner_votes < 2:
         winner["disagreement"] = True


### PR DESCRIPTION
## Summary

- `_vote_single_word_translation` now attaches a deduped, vote-ordered `alternatives` list (winner at index 0, with vote counts) on every return path. The 3-way vote already runs Azure + Google + DeepL in parallel on every word tap — this just stops throwing the losing buckets away when they happened to agree with the winner.
- `/get_one_translation` forwards the new field. Legacy `competing_translations` / `disagreement` kept during the deprecation window so the extension build (which ships behind the web app) stays green.
- New `POST /ask_llm_translation/<from>/<to>` — synchronous, single-shot LLM call. Replaces the LLM round trip that the SSE menu used to issue on every menu open.

See [ADR 022](https://github.com/zeeguu/docs/blob/main/adr/022-return-all-provider-translations-from-get-one-translation.md) for the full rationale (problem #1: duplicate API calls; problem #2: the streamed menu shifts under the user's finger between intent and tap; problem #3: zeeguu/web#1108's onboarding trigger was reaching for a field that didn't exist).

Pairs with zeeguu/web#TBD.

## Test plan

- [ ] `pytest zeeguu/core/test/test_translation_voter_alternatives.py` — 6 tests covering all voter return paths (unanimous, 2-vs-1, 3-way split, single success, Microsoft fallback, total failure).
- [ ] Tap a word in the reader; inspect the network response for `/get_one_translation` and confirm `alternatives` is present with winner at index 0.
- [ ] Hit `POST /ask_llm_translation/da/en` with `{ word, context }` and confirm a `{ translation, source }` payload.
- [ ] Confirm `competing_translations` / `disagreement` are still populated for backward compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)