### PR TITLE
Ask-LLM: use a general-purpose prompt for single words

### DIFF
--- a/zeeguu/core/llm_services/mwe_translation_service.py
+++ b/zeeguu/core/llm_services/mwe_translation_service.py
@@ -46,6 +46,79 @@ Return ONLY the translation, nothing else.
 Translation:"""
 
 
+# Used by the explicit "Ask LLM" action in the reader's AlterMenu (ADR 022).
+# The reader passes any word the learner clicks on — single words, contiguous
+# phrases, names, etc. — so this prompt cannot assume MWE structure; it just
+# asks for a concise translation of the highlighted span.
+GENERAL_WORD_TRANSLATION_PROMPT = """Translate the word or phrase "{word}" in context.
+
+It appears in this {source_lang} sentence:
+"{sentence}"
+
+Translate "{word}" to {target_lang}.
+- Give a concise translation (1-3 words)
+- Match the sense the word carries in this sentence
+- If the word is a single word, return its meaning here (not a paraphrase of the whole sentence)
+
+Return ONLY the translation, nothing else.
+
+Translation:"""
+
+
+def translate_word_in_context(
+    word: str,
+    sentence: str,
+    source_lang: str,
+    target_lang: str = "en",
+    timeout: int = 30,
+) -> Optional[str]:
+    """
+    General-purpose LLM translation for a single word or phrase, given the
+    sentence it appears in. Used by the "Ask LLM" action in the reader.
+
+    Unlike ``translate_separated_mwe``, this does not frame the input as an
+    MWE — it works equally well for single words, contiguous phrases, and
+    names. Returns the translated string, or None if the LLM call failed
+    (missing API key, network error, etc.).
+    """
+    source_name = LANG_NAMES.get(source_lang, source_lang)
+    target_name = LANG_NAMES.get(target_lang, target_lang)
+
+    prompt = GENERAL_WORD_TRANSLATION_PROMPT.format(
+        word=word,
+        sentence=sentence,
+        source_lang=source_name,
+        target_lang=target_name,
+    )
+
+    try:
+        import anthropic
+
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            logger.warning("ANTHROPIC_API_KEY not set, cannot ask LLM for translation")
+            return None
+
+        client = anthropic.Anthropic(api_key=api_key, timeout=timeout)
+
+        response = client.messages.create(
+            model="claude-sonnet-4-20250514",
+            max_tokens=50,
+            temperature=0.1,
+            messages=[{"role": "user", "content": prompt}],
+        )
+
+        translation = response.content[0].text.strip().strip('"\'.')
+        logger.debug(f"LLM translated '{word}' -> '{translation}'")
+        return translation or None
+    except ImportError:
+        logger.error("anthropic package not installed")
+        return None
+    except Exception as e:
+        logger.error(f"LLM word translation failed for '{word}': {e}")
+        return None
+
+
 def translate_separated_mwe(
     mwe_text: str,
     sentence: str,

--- a/zeeguu/core/translation_services/translator.py
+++ b/zeeguu/core/translation_services/translator.py
@@ -573,23 +573,27 @@ def translate_separated_mwe(word, sentence, from_lang, to_lang):
 @lru_cache(maxsize=1000)
 def translate_with_llm(word, sentence, from_lang, to_lang):
     """
-    Translate a word or MWE using an LLM.
+    Translate a word or phrase using an LLM. Used by the "Ask LLM" action
+    in the reader (ADR 022) — gating it behind an explicit click means we
+    only pay the LLM cost when a learner actually asks for it.
 
-    Useful for separated MWEs where the LLM understands grammar better.
+    Routes single words and contiguous phrases through the general
+    word-in-context prompt; routes separated MWEs through the MWE-aware
+    prompt that knows how to handle the "rufe...an" shape.
 
-    Args:
-        word: The word/MWE to translate (e.g., "rufe ... an")
-        sentence: The sentence containing the word
-        from_lang: Source language code
-        to_lang: Target language code
-
-    Returns:
-        dict with 'translation', 'source', 'likelihood' keys, or None
+    Returns ``{translation, source, likelihood}`` or None if the LLM call
+    failed (missing API key, network error, etc.).
     """
     try:
-        from zeeguu.core.llm_services.mwe_translation_service import translate_separated_mwe as llm_translate
+        from zeeguu.core.llm_services.mwe_translation_service import (
+            translate_separated_mwe,
+            translate_word_in_context,
+        )
 
-        translation = llm_translate(word, sentence, from_lang, to_lang)
+        if "..." in word:
+            translation = translate_separated_mwe(word, sentence, from_lang, to_lang)
+        else:
+            translation = translate_word_in_context(word, sentence, from_lang, to_lang)
 
         if translation:
             return {


### PR DESCRIPTION
## Summary

Follow-up to #624. Caught in testing: \`/ask_llm_translation\` was routing every call through \`translate_separated_mwe\`, whose prompt tells Claude *"the MWE parts may be separated, e.g. rufe...an = anrufen"*. For a single word like "tæt" that framing derails the model and the response often comes back empty or wrong — so in the reader, clicking "Ask LLM" looked like the option just vanished and nothing happened.

- New \`translate_word_in_context\` in \`mwe_translation_service.py\` with a plain word-in-sentence prompt; no MWE framing.
- \`translate_with_llm\` now routes \`"foo...bar"\`-shaped inputs to the existing MWE prompt and everything else to the general one.

## Test plan

- [ ] In the reader, translate a single word (e.g. Danish "tæt"), open the AlterMenu, click "Ask LLM" — a new row should appear with the LLM's reading of that word in that sentence.
- [ ] Translate a separated MWE (German "rufe ... an"), click "Ask LLM" — the MWE-framed prompt path still fires and returns the right thing.
- [ ] Without \`ANTHROPIC_API_KEY\` set, the endpoint returns 404 (logged, no crash) and the AlterMenu shows "Ask LLM — try again" rather than silently removing the option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)