### PR TITLE
Home-page cards: overlay simplified summary, keep original title

### DIFF
--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -525,18 +525,25 @@ def get_user_info_from_content_recommendations(user, content_list):
 
 def _apply_simplified_display_overlay(user, results):
     """
-    Overlay simplified title/summary (and tokenized variants) onto result
-    dicts that point at an original article, when a CEFR-matched simplified
-    child exists. Result ids, urls, and parent linkage are untouched — only
-    the displayed text changes, so external-open routing is preserved.
-    Falls back silently to the original when no level match exists.
+    Overlay the simplified *summary* onto result dicts that point at an
+    original article, when a CEFR-matched simplified child exists. The
+    title is intentionally left as the original's — when the user clicks
+    through to the publisher (copyright forces external open) they must
+    see the same headline they tapped, so swapping the title would feel
+    like a bait-and-switch. Summary is more "preview blurb" than headline
+    and the publisher's article body doesn't compete with it.
 
-    Batched: at most three round-trips regardless of feed size —
-    one for simplified children (+ joined CEFR assessments), one for
-    their tokenization caches, and any commits needed to populate
-    missing caches. past_bookmarks for the overlay are intentionally
-    skipped on the card (the simplified text isn't what's behind the
-    Open link); they're surfaced again inside the reader itself.
+    Result ids, urls, and parent linkage are untouched, so the "Simplified"
+    badge, save state, and external-open routing in ArticlePreview are
+    unchanged. Falls back silently to the original summary when no level
+    match exists.
+
+    Batched: one IN-query for simplified children (+ joined CEFR
+    assessments), one for their tokenization caches. past_bookmarks for
+    the overlay summary are intentionally [] on the card — they live
+    against the simplified article id, not the original behind the Open
+    link, and the reader surfaces them again when the user opens the
+    simplified version explicitly.
     """
     import json
     from sqlalchemy.orm import joinedload
@@ -612,32 +619,20 @@ def _apply_simplified_display_overlay(user, results):
         display = overlays.get(result["id"])
         if not display:
             continue
-        result["title"] = display.title
-        if display.summary and len(display.summary.strip()) > 10:
-            result["summary"] = display.summary
+        if not display.summary or len(display.summary.strip()) <= 10:
+            continue
+        result["summary"] = display.summary
 
         cache = caches.get(display.id)
-        if not cache:
+        if not cache or not cache.tokenized_summary:
             continue
-        if cache.tokenized_title:
-            try:
-                tokens = json.loads(cache.tokenized_title)
-                ctx = ContextIdentifier(ContextType.ARTICLE_TITLE, article_id=display.id)
-                result["interactiveTitle"] = {
-                    "tokens": tokens,
-                    "context_identifier": ctx.as_dictionary(),
-                    "past_bookmarks": [],
-                }
-            except (json.JSONDecodeError, TypeError):
-                pass
-        if display.summary and cache.tokenized_summary:
-            try:
-                tokens = json.loads(cache.tokenized_summary)
-                ctx = ContextIdentifier(ContextType.ARTICLE_SUMMARY, article_id=display.id)
-                result["interactiveSummary"] = {
-                    "tokens": tokens,
-                    "context_identifier": ctx.as_dictionary(),
-                    "past_bookmarks": [],
-                }
-            except (json.JSONDecodeError, TypeError):
-                pass
+        try:
+            tokens = json.loads(cache.tokenized_summary)
+            ctx = ContextIdentifier(ContextType.ARTICLE_SUMMARY, article_id=display.id)
+            result["interactiveSummary"] = {
+                "tokens": tokens,
+                "context_identifier": ctx.as_dictionary(),
+                "past_bookmarks": [],
+            }
+        except (json.JSONDecodeError, TypeError):
+            pass

--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -512,6 +512,132 @@ def get_user_info_from_content_recommendations(user, content_list):
         if root_id and root_id in matched_searches_by_root:
             result['matched_searches'] = matched_searches_by_root[root_id]
 
+    # Home-page display overlay: always_open_externally users get originals
+    # in their feed (link target stays external), but the card should still
+    # preview the level-matched simplified title/summary when one exists.
+    if user.has_feature("always_open_externally"):
+        _apply_simplified_display_overlay(user, results)
+
     results.extend([UserVideo.user_video_info(user, v) for v in videos])
 
     return results
+
+
+def _apply_simplified_display_overlay(user, results):
+    """
+    Overlay simplified title/summary (and tokenized variants) onto result
+    dicts that point at an original article, when a CEFR-matched simplified
+    child exists. Result ids, urls, and parent linkage are untouched — only
+    the displayed text changes, so external-open routing is preserved.
+    Falls back silently to the original when no level match exists.
+
+    Batched: at most three round-trips regardless of feed size —
+    one for simplified children (+ joined CEFR assessments), one for
+    their tokenization caches, and any commits needed to populate
+    missing caches. past_bookmarks for the overlay are intentionally
+    skipped on the card (the simplified text isn't what's behind the
+    Open link); they're surfaced again inside the reader itself.
+    """
+    import json
+    from sqlalchemy.orm import joinedload
+    from zeeguu.core.model import db
+    from zeeguu.core.model.article_tokenization_cache import ArticleTokenizationCache
+    from zeeguu.core.model.context_identifier import ContextIdentifier
+    from zeeguu.core.model.context_type import ContextType
+
+    try:
+        user_cefr_level = user.cefr_level_for_learned_language()
+    except (AttributeError, IndexError, TypeError):
+        return
+    if not user_cefr_level:
+        return
+
+    candidate_ids = [
+        r["id"] for r in results
+        if not r.get("parent_article_id") and not r.get("has_uploader")
+    ]
+    if not candidate_ids:
+        return
+
+    children = (
+        Article.query
+        .options(joinedload(Article.cefr_assessment))
+        .filter(Article.parent_article_id.in_(candidate_ids))
+        .all()
+    )
+    if not children:
+        return
+
+    def matches(child):
+        level = (
+            child.cefr_assessment.effective_cefr_level
+            if child.cefr_assessment and child.cefr_assessment.effective_cefr_level
+            else child.cefr_level
+        )
+        if not level:
+            return False
+        if level == user_cefr_level:
+            return True
+        if "/" in level:
+            lo, hi = level.split("/")
+            return user_cefr_level in (lo, hi)
+        return False
+
+    # First level-matching child wins, mirroring get_appropriate_version_for_user_level
+    overlays = {}  # original_id -> simplified Article
+    for child in children:
+        if child.parent_article_id in overlays:
+            continue
+        if matches(child):
+            overlays[child.parent_article_id] = child
+
+    if not overlays:
+        return
+
+    display_articles = list(overlays.values())
+    display_ids = [a.id for a in display_articles]
+    caches = {
+        c.article_id: c
+        for c in db.session.query(ArticleTokenizationCache)
+        .filter(ArticleTokenizationCache.article_id.in_(display_ids))
+        .all()
+    }
+    for article in display_articles:
+        if article.id not in caches:
+            cache, _ = ArticleTokenizationCache.ensure_populated(db.session, article)
+            caches[article.id] = cache
+    db.session.commit()
+
+    for result in results:
+        display = overlays.get(result["id"])
+        if not display:
+            continue
+        result["title"] = display.title
+        if display.summary and len(display.summary.strip()) > 10:
+            result["summary"] = display.summary
+
+        cache = caches.get(display.id)
+        if not cache:
+            continue
+        if cache.tokenized_title:
+            try:
+                tokens = json.loads(cache.tokenized_title)
+                ctx = ContextIdentifier(ContextType.ARTICLE_TITLE, article_id=display.id)
+                result["interactiveTitle"] = {
+                    "tokens": tokens,
+                    "context_identifier": ctx.as_dictionary(),
+                    "past_bookmarks": [],
+                }
+            except (json.JSONDecodeError, TypeError):
+                pass
+        if display.summary and cache.tokenized_summary:
+            try:
+                tokens = json.loads(cache.tokenized_summary)
+                ctx = ContextIdentifier(ContextType.ARTICLE_SUMMARY, article_id=display.id)
+                result["interactiveSummary"] = {
+                    "tokens": tokens,
+                    "context_identifier": ctx.as_dictionary(),
+                    "past_bookmarks": [],
+                }
+            except (json.JSONDecodeError, TypeError):
+                pass


### PR DESCRIPTION
## Summary

- For `always_open_externally` users, the recommended feed serves originals (the card link goes to the publisher, copyright). When a CEFR-matched simplified child exists for an original, overlay only its **summary** onto the result dict.
- Title stays as the original's so the headline on the card matches what the user sees at the publisher on click-through and on return.
- Summary is preview-blurb territory — the publisher's article body doesn't display its own summary against ours, so the cleaner LLM-simplified summary on the card doesn't create the same dissonance.
- Falls back silently to the original summary when no level-matched child exists (B2+ users, originals without a child at the user's level).

## Implementation notes

- New helper `_apply_simplified_display_overlay` in `elastic_recommender.py`, called from `get_user_info_from_content_recommendations` after the matched-searches merge.
- Batched: one IN-query for simplified children (with `cefr_assessment` eager-loaded), one for their tokenization caches. No N+1 on feed size.
- `past_bookmarks` on the overlay summary is intentionally `[]` on the card. The bookmarks live against the simplified article id, not the original behind the Open link, and the reader still fetches its own bookmarks when the user opens the simplified version explicitly.

## Test plan

- [ ] Hit `/user_articles/recommended` as a user with `always_open_externally` and a CEFR level where simplified children exist; confirm card summary comes from the simplified version while the title stays original.
- [ ] Same user, original without a level-matched child: card shows original summary unchanged.
- [ ] B2+ user (no simplified inventory): no overlays applied, feed unchanged.
- [ ] Default (non-`always_open_externally`) user: behavior unchanged (helper not invoked).
- [ ] Click-through: open the publisher → headline matches the card title. Return to feed → still matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)