### PR TITLE
Drop original_title field from overlay

### DIFF
--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -527,11 +527,9 @@ def _apply_simplified_display_overlay(user, results):
     """
     Overlay the simplified *title* and *summary* onto result dicts that
     point at an original article, when a CEFR-matched simplified child
-    exists. The publisher's original title is preserved on the result
-    as `original_title` so the card can display it as a small subtitle
-    underneath — this way the user sees both the readable simplified
-    headline and the actual publisher headline they'll land on when
-    they click through (copyright forces external open).
+    exists. The publisher's headline is reachable via the article's
+    source/url at the publisher itself — no need to surface it on the
+    card.
 
     Result ids, urls, and parent linkage are untouched, so the
     "Simplified" badge, save state, and external-open routing in
@@ -620,11 +618,6 @@ def _apply_simplified_display_overlay(user, results):
         if not display:
             continue
 
-        # Keep the publisher's title accessible to the frontend so the
-        # card can render it as a small subtitle under the simplified
-        # one — that way clicking through to the publisher isn't a
-        # surprise.
-        result["original_title"] = result["title"]
         result["title"] = display.title
 
         if display.summary and len(display.summary.strip()) > 10:


### PR DESCRIPTION
Frontend's not using it — tried rendering it as a small subtitle under the simplified title and the result read as a competing second-headline rather than metadata. The publisher domain in the meta strip is enough of a bridge.

Removes the `original_title` field and the docstring section that justified it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)