### PR TITLE
Home cards: highlight past translations on simplified titles/summaries

### DIFF
--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -538,15 +538,17 @@ def _apply_simplified_display_overlay(user, results):
 
     Batched: one IN-query for simplified children (+ joined CEFR
     assessments), one for their tokenization caches. past_bookmarks
-    for the overlay are intentionally [] on the card — they live
-    against the simplified article id, not the original behind the
-    Open link, and the reader surfaces them again when the user
-    opens the simplified version explicitly.
+    are populated against the simplified article's id — the card lives
+    over the simplified content (title/summary come from there), so
+    the bookmarks the user made while reading that simplified article
+    are the right ones to highlight.
     """
     import json
     from sqlalchemy.orm import joinedload
     from zeeguu.core.model import db
     from zeeguu.core.model.article_tokenization_cache import ArticleTokenizationCache
+    from zeeguu.core.model.article_title_context import ArticleTitleContext
+    from zeeguu.core.model.article_summary_context import ArticleSummaryContext
     from zeeguu.core.model.context_identifier import ContextIdentifier
     from zeeguu.core.model.context_type import ContextType
 
@@ -633,7 +635,9 @@ def _apply_simplified_display_overlay(user, results):
                 result["interactiveTitle"] = {
                     "tokens": tokens,
                     "context_identifier": ctx.as_dictionary(),
-                    "past_bookmarks": [],
+                    "past_bookmarks": ArticleTitleContext.get_all_user_bookmarks_for_article_title(
+                        user.id, display.id
+                    ),
                 }
             except (json.JSONDecodeError, TypeError):
                 pass
@@ -644,7 +648,9 @@ def _apply_simplified_display_overlay(user, results):
                 result["interactiveSummary"] = {
                     "tokens": tokens,
                     "context_identifier": ctx.as_dictionary(),
-                    "past_bookmarks": [],
+                    "past_bookmarks": ArticleSummaryContext.get_all_user_bookmarks_for_article_summary(
+                        user.id, display.id
+                    ),
                 }
             except (json.JSONDecodeError, TypeError):
                 pass


### PR DESCRIPTION
## Summary

The home-card simplified overlay (#629) hardcoded \`past_bookmarks=[]\`, so words you'd previously translated stopped getting highlighted on simplified titles even though it kept working on the original-title cards. Reasoning at the time was "bookmarks belong to the simplified article id, not the original behind the Open link" — but the card is *displaying* the simplified content, so its bookmarks are exactly the right ones to highlight.

Looks them up per overlay article via the existing \`ArticleTitleContext\` / \`ArticleSummaryContext\` helpers used by the reader path.

## Test plan

- [ ] On the home page, find a simplified card for an article you've previously read and translated words in. Past-translation underlines now appear on the simplified title/summary.
- [ ] Cards without simplified overlay (B2+ users, originals without level match) still show their past translations.
- [ ] Card click-through still goes to the original (publisher) — no change to routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)