### PR TITLE
Strip trailing ellipsis from summary; fix LLM simplification prompt

### DIFF
--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -546,6 +546,10 @@ def _apply_simplified_display_overlay(user, results):
     import json
     from sqlalchemy.orm import joinedload
     from zeeguu.core.model import db
+    from zeeguu.core.model.article import (
+        strip_trailing_ellipsis,
+        strip_trailing_ellipsis_tokens_json,
+    )
     from zeeguu.core.model.article_tokenization_cache import ArticleTokenizationCache
     from zeeguu.core.model.article_title_context import ArticleTitleContext
     from zeeguu.core.model.article_summary_context import ArticleSummaryContext
@@ -623,7 +627,7 @@ def _apply_simplified_display_overlay(user, results):
         result["title"] = display.title
 
         if display.summary and len(display.summary.strip()) > 10:
-            result["summary"] = display.summary
+            result["summary"] = strip_trailing_ellipsis(display.summary)
 
         cache = caches.get(display.id)
         if not cache:
@@ -643,7 +647,9 @@ def _apply_simplified_display_overlay(user, results):
                 pass
         if display.summary and cache.tokenized_summary:
             try:
-                tokens = json.loads(cache.tokenized_summary)
+                tokens = json.loads(
+                    strip_trailing_ellipsis_tokens_json(cache.tokenized_summary)
+                )
                 ctx = ContextIdentifier(ContextType.ARTICLE_SUMMARY, article_id=display.id)
                 result["interactiveSummary"] = {
                     "tokens": tokens,

--- a/zeeguu/core/llm_services/prompts/article_simplification.py
+++ b/zeeguu/core/llm_services/prompts/article_simplification.py
@@ -94,7 +94,7 @@ ARTICLE_TYPE: [NEWS or GENERAL - NEWS = current events tied to a specific time (
 
 ORIGINAL_LEVEL: [assess the CEFR level of the original article: A1, A2, B1, B2, C1, or C2]
 
-ORIGINAL_SUMMARY: [concise plain text summary (NO markdown formatting, no bold/italic) in <<LANGUAGE_NAME>>, maximum 25 words. State the article's key facts/claims directly. DO NOT use meta-preambles like "The article tells about...", "This article is about...", "Artiklen fortæller om...", "L'article parle de...", "Der Artikel handelt von...", "El artículo trata de...". Just state the content as if reporting it yourself.]
+ORIGINAL_SUMMARY: [concise plain text summary (NO markdown formatting, no bold/italic) in <<LANGUAGE_NAME>>, maximum 25 words. State the article's key facts/claims directly. DO NOT use meta-preambles like "The article tells about...", "This article is about...", "Artiklen fortæller om...", "L'article parle de...", "Der Artikel handelt von...", "El artículo trata de...". Just state the content as if reporting it yourself. End with a complete sentence and a single period — DO NOT end with an ellipsis (… or ...) or trailing dots.]
 
 SIMPLIFIED_LEVELS: [list the levels you will create, e.g., "A1,A2" or "A1,A2,B1" - leave empty if original is A1]
 
@@ -104,7 +104,7 @@ SIMPLIFIED_LEVELS: [list the levels you will create, e.g., "A1,A2" or "A1,A2,B1"
 
 [LEVEL]_CONTENT: [write simplified content in <<LANGUAGE_NAME>> using Markdown formatting]
 
-[LEVEL]_SUMMARY: [concise plain text summary (NO markdown formatting, no bold/italic) in <<LANGUAGE_NAME>> using vocabulary appropriate for this level, maximum 25 words. State the article's key facts/claims directly. DO NOT use meta-preambles like "The article tells about...", "This article is about...", "Artiklen fortæller om...", "L'article parle de...", "Der Artikel handelt von...", "El artículo trata de...". Just state the content as if reporting it yourself.]
+[LEVEL]_SUMMARY: [concise plain text summary (NO markdown formatting, no bold/italic) in <<LANGUAGE_NAME>> using vocabulary appropriate for this level, maximum 25 words. State the article's key facts/claims directly. DO NOT use meta-preambles like "The article tells about...", "This article is about...", "Artiklen fortæller om...", "L'article parle de...", "Der Artikel handelt von...", "El artículo trata de...". Just state the content as if reporting it yourself. End with a complete sentence and a single period — DO NOT end with an ellipsis (… or ...) or trailing dots.]
 
 <<LANGUAGE_NAME>> = {language_name}
 

--- a/zeeguu/core/llm_services/prompts/article_simplification.py
+++ b/zeeguu/core/llm_services/prompts/article_simplification.py
@@ -94,7 +94,7 @@ ARTICLE_TYPE: [NEWS or GENERAL - NEWS = current events tied to a specific time (
 
 ORIGINAL_LEVEL: [assess the CEFR level of the original article: A1, A2, B1, B2, C1, or C2]
 
-ORIGINAL_SUMMARY: [concise plain text summary (NO markdown formatting, no bold/italic) in <<LANGUAGE_NAME>>, maximum 25 words. State the article's key facts/claims directly. DO NOT use meta-preambles like "The article tells about...", "This article is about...", "Artiklen fortæller om...", "L'article parle de...", "Der Artikel handelt von...", "El artículo trata de...". Just state the content as if reporting it yourself. End with a complete sentence and a single period — DO NOT end with an ellipsis (… or ...) or trailing dots.]
+ORIGINAL_SUMMARY: [concise plain text summary (NO markdown formatting, no bold/italic) in <<LANGUAGE_NAME>>, maximum 25 words. State the article's key facts/claims directly. DO NOT use meta-preambles like "The article tells about...", "This article is about...", "Artiklen fortæller om...", "L'article parle de...", "Der Artikel handelt von...", "El artículo trata de...". Just state the content as if reporting it yourself.]
 
 SIMPLIFIED_LEVELS: [list the levels you will create, e.g., "A1,A2" or "A1,A2,B1" - leave empty if original is A1]
 
@@ -104,7 +104,7 @@ SIMPLIFIED_LEVELS: [list the levels you will create, e.g., "A1,A2" or "A1,A2,B1"
 
 [LEVEL]_CONTENT: [write simplified content in <<LANGUAGE_NAME>> using Markdown formatting]
 
-[LEVEL]_SUMMARY: [concise plain text summary (NO markdown formatting, no bold/italic) in <<LANGUAGE_NAME>> using vocabulary appropriate for this level, maximum 25 words. State the article's key facts/claims directly. DO NOT use meta-preambles like "The article tells about...", "This article is about...", "Artiklen fortæller om...", "L'article parle de...", "Der Artikel handelt von...", "El artículo trata de...". Just state the content as if reporting it yourself. End with a complete sentence and a single period — DO NOT end with an ellipsis (… or ...) or trailing dots.]
+[LEVEL]_SUMMARY: [concise plain text summary (NO markdown formatting, no bold/italic) in <<LANGUAGE_NAME>> using vocabulary appropriate for this level, maximum 25 words. State the article's key facts/claims directly. DO NOT use meta-preambles like "The article tells about...", "This article is about...", "Artiklen fortæller om...", "L'article parle de...", "Der Artikel handelt von...", "El artículo trata de...". Just state the content as if reporting it yourself.]
 
 <<LANGUAGE_NAME>> = {language_name}
 

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -36,6 +36,62 @@ HTML_TAG_CLEANR = re.compile("<[^>]*>")
 
 MULTIPLE_NEWLINES = re.compile(r"\n\s*\n")
 
+# Matches a trailing Unicode ellipsis (…), 2+ ASCII dots, or any mix of the
+# two, optionally with surrounding whitespace, at end of string. Preserves a
+# single sentence-ending period. The LLM-simplification prompt and most RSS
+# publishers both pin a teaser ellipsis onto summaries; on the home card
+# that reads as "every sentence is unfinished" — see ~60k Danish simplified
+# summaries with trailing …. (Stripped at serve time, not on the row, so
+# nothing about the underlying article is mutated.)
+_TRAILING_ELLIPSIS_RE = re.compile(r"\s*(?:[…\.]{2,}|…)\s*$")
+
+
+def strip_trailing_ellipsis(text):
+    """Strip a trailing Unicode … or ≥2 ASCII dots from `text`. Single
+    sentence-ending period preserved."""
+    if not text:
+        return text
+    return _TRAILING_ELLIPSIS_RE.sub("", text).rstrip()
+
+
+def _token_text_is_ellipsis(text):
+    text = (text or "").strip()
+    if not text:
+        return False
+    if text == "…":
+        return True
+    return bool(re.fullmatch(r"[.…]{2,}", text))
+
+
+def strip_trailing_ellipsis_tokens_json(tokens_json):
+    """Given a JSON string of tokenized paragraphs/sentences/tokens (as
+    cached in ArticleTokenizationCache), drop trailing ellipsis tokens
+    from the very end. Returns the cleaned JSON string (unchanged if
+    parsing fails or no trailing ellipsis token is found)."""
+    if not tokens_json:
+        return tokens_json
+    import json
+
+    try:
+        sentences = json.loads(tokens_json)
+    except (json.JSONDecodeError, TypeError):
+        return tokens_json
+    if not isinstance(sentences, list):
+        return tokens_json
+
+    changed = False
+    for sentence in reversed(sentences):
+        if not isinstance(sentence, list):
+            continue
+        while sentence and isinstance(sentence[-1], dict) and _token_text_is_ellipsis(
+            sentence[-1].get("text")
+        ):
+            sentence.pop()
+            changed = True
+        if sentence:
+            break
+    return json.dumps(sentences) if changed else tokens_json
+
 
 class UnsignedBigInteger(TypeDecorator):
     """Handles unsigned 64-bit integers for both MySQL and SQLite."""
@@ -612,6 +668,7 @@ class Article(db.Model):
             summary = self.summary
         else:
             summary = self.get_content()[:MAX_CHAR_COUNT_IN_SUMMARY]
+        summary = strip_trailing_ellipsis(summary)
         fk_difficulty = self.get_fk_difficulty()
 
         # Use effective_cefr_level from assessment table (SINGLE SOURCE OF TRUTH)

--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -726,7 +726,10 @@ class UserArticle(db.Model):
         # Build summary response
         if article.summary and cache.tokenized_summary:
             try:
-                tokenized_summary = json.loads(cache.tokenized_summary)
+                from zeeguu.core.model.article import strip_trailing_ellipsis_tokens_json
+                tokenized_summary = json.loads(
+                    strip_trailing_ellipsis_tokens_json(cache.tokenized_summary)
+                )
                 summary_context_id = ContextIdentifier(
                     ContextType.ARTICLE_SUMMARY, article_id=article.id
                 )


### PR DESCRIPTION
## Summary

The LLM-simplification prompt was teaching Claude to end summaries with a Unicode ellipsis — about **60k Danish simplified summaries** in prod end with \`…\`. On the home card that reads as "every sentence is unfinished" (the card is already an obvious click-to-read; the teaser \`…\` is just noise).

Three changes, all serve-time / prompt-time — no DB writes:

- \`strip_trailing_ellipsis\` on the plain summary string in \`Article.article_info\` and the home-card overlay. Preserves a single sentence-ending period; strips Unicode \`…\` or any run of 2+ ASCII dots.
- \`strip_trailing_ellipsis_tokens_json\` on the cached tokenized summary (interactiveSummary on the home card, tokenized_summary in the reader preview). Pops trailing ellipsis tokens off the last sentence so the tap-to-translate rendering matches the plain string.
- LLM simplification prompt explicitly forbids trailing ellipsis on both \`ORIGINAL_SUMMARY\` and per-level summaries.

## Test plan

- [ ] Home feed: Danish simplified cards no longer show \`…\` at the end of their summaries (both plain text and tokenized rendering).
- [ ] Article reader preview: same.
- [ ] Single sentence-ending \`.\` is preserved (we don't accidentally strip normal punctuation).
- [ ] New simplifications written by the LLM end without \`…\`.
- [ ] No errors in tokenized_summary parsing for cache rows with weird content (the helper falls back to returning the original JSON on parse failure).

## Follow-up

If we want clean data at source, a one-shot SQL migration over the existing 60k summaries (Unicode-ellipsis-trailing rows) would be cheap. Not blocking; the serve-time strip already hides the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)