### PR TITLE
Redesign shared-lesson OG card: title-forward + play/soundform

### DIFF
--- a/zeeguu/api/endpoints/audio_lessons.py
+++ b/zeeguu/api/endpoints/audio_lessons.py
@@ -194,7 +194,7 @@ def create_lesson_share_link(lesson_id):
 
 def _preview_texts(view):
     """Build the (page/OG title, description) for a shared lesson's link preview."""
-    title = (view.get("title") or "Audio lesson").strip()
+    title = og_image.clean_lesson_title((view.get("title") or "Audio lesson").strip())
     language = view.get("language_name")
     cefr = view.get("cefr_level")
     lesson_type = view.get("lesson_type")

--- a/zeeguu/core/audio_lessons/og_image.py
+++ b/zeeguu/core/audio_lessons/og_image.py
@@ -144,7 +144,8 @@ def render_card(view):
         "Zeeguu", font=wordmark, fill=ORANGE_DEEP)
 
     language = view.get("language_name")
-    label = f"{language} Audio Lesson" if language else "Audio Lesson"
+    # The play button + soundform already say "audio", so the pill needn't repeat it.
+    label = f"{language} Lesson" if language else "Lesson"
     pill_font = _font("Bold", 42)
     lw = draw.textlength(label, font=pill_font)
     asc, desc = pill_font.getmetrics()

--- a/zeeguu/core/audio_lessons/og_image.py
+++ b/zeeguu/core/audio_lessons/og_image.py
@@ -145,14 +145,14 @@ def render_card(view):
 
     language = view.get("language_name")
     label = f"{language} Audio Lesson" if language else "Audio Lesson"
-    pill_font = _font("Bold", 34)
+    pill_font = _font("Bold", 42)
     lw = draw.textlength(label, font=pill_font)
     asc, desc = pill_font.getmetrics()
-    pill_top = MARGIN + 10
+    pill_top = MARGIN + 4
     draw.rounded_rectangle(
-        (WIDTH - MARGIN - lw - 52, pill_top, WIDTH - MARGIN, pill_top + asc + desc + 26),
-        radius=46, fill=ORANGE)
-    draw.text((WIDTH - MARGIN - lw - 26, pill_top + 13), label, font=pill_font, fill=WHITE)
+        (WIDTH - MARGIN - lw - 60, pill_top, WIDTH - MARGIN, pill_top + asc + desc + 30),
+        radius=52, fill=ORANGE)
+    draw.text((WIDTH - MARGIN - lw - 30, pill_top + 15), label, font=pill_font, fill=WHITE)
 
     # --- Title (hero): auto-fit, vertically centred between header and audio band ---
     title = clean_lesson_title((view.get("title") or "Audio lesson").strip())

--- a/zeeguu/core/audio_lessons/og_image.py
+++ b/zeeguu/core/audio_lessons/og_image.py
@@ -3,16 +3,21 @@ Open Graph preview card for a shared audio lesson.
 
 Social scrapers (WhatsApp, iMessage, Slack, Facebook, ...) don't run JS, so a
 shared `/shared-lesson/<uuid>` link otherwise falls back to the generic site
-preview. This renders a 1200x630 PNG card from a lesson's public view dict
-(the same data returned by DailyLessonGenerator.get_shared_lesson_view) so the
-preview shows the actual lesson: title, language, duration, CEFR level, words.
+preview. This renders a 1200x630 PNG card from a lesson's public view dict.
+
+Design: the card is read at thumbnail size, so it carries only what survives
+shrinking — the brand, the title as hero, a "<Language> Audio Lesson" pill, and
+a play + soundform "listen" cue. Per-lesson metadata (duration, level, type)
+lives in the og:description text instead, which stays legible at any size.
 
 Pure function of the view dict + brand assets — no DB access — so it's trivial
-to unit-test and to render samples. Cards are immutable per lesson, so callers
+to unit-test and render samples. Cards are immutable per lesson, so callers
 cache the PNG on disk (see ensure_cached_card).
 """
 
+import math
 import os
+import random
 from functools import lru_cache
 
 import zeeguu
@@ -28,12 +33,10 @@ _LOGO_PATH = os.path.join(_ASSETS, "images", "zeeguu-logo.png")
 
 # Warm Zeeguu palette (mirrors web/src/components/colors.js).
 BG_TOP = (255, 248, 230)      # cream
-BG_BOTTOM = (255, 230, 188)   # light amber
-INK = (74, 50, 8)             # dark brown — primary text
-INK_SOFT = (140, 110, 60)     # muted brown — secondary text
-ORANGE = (255, 168, 40)       # zeeguuOrange-ish, brand accent
-ORANGE_DEEP = (196, 120, 24)  # darker orange for the wordmark
-CHIP_BORDER = (224, 190, 130)
+BG_BOTTOM = (255, 228, 186)   # light amber
+INK = (74, 50, 8)             # dark brown — title
+ORANGE = (255, 168, 40)       # brand accent / soundform
+ORANGE_DEEP = (196, 120, 24)  # wordmark / play button
 WHITE = (255, 255, 255)
 
 
@@ -42,178 +45,132 @@ def _font(weight, size):
     return ImageFont.truetype(os.path.join(_FONTS, f"Montserrat-{weight}.ttf"), size)
 
 
-def _text_w(draw, text, font):
-    return draw.textlength(text, font=font)
+def clean_lesson_title(title):
+    """Drop the "Topic: " / "Situation: " prefix that display_title() prepends —
+    it's clutter on a share card / preview title."""
+    if not title:
+        return title
+    for prefix in ("Topic: ", "Situation: "):
+        if title.startswith(prefix):
+            return title[len(prefix):]
+    return title
 
 
-def _wrap(draw, text, font, max_width, max_lines):
-    """Greedy word wrap; the last line gets an ellipsis if text is truncated."""
-    words = text.split()
-    lines, current = [], ""
+def _wrap(draw, text, font, max_width):
+    words, lines, current = text.split(), [], ""
     for word in words:
         candidate = f"{current} {word}".strip()
-        if _text_w(draw, candidate, font) <= max_width or not current:
+        if draw.textlength(candidate, font=font) <= max_width or not current:
             current = candidate
         else:
             lines.append(current)
             current = word
-            if len(lines) == max_lines:
-                break
-    if len(lines) < max_lines and current:
+    if current:
         lines.append(current)
-
-    truncated = len(lines) == max_lines and (
-        current != lines[-1] or len(" ".join(words)) > len(" ".join(lines))
-    )
-    if truncated:
-        last = lines[-1]
-        while last and _text_w(draw, last + "…", font) > max_width:
-            last = last[:-1].rstrip()
-        lines[-1] = last + "…"
     return lines
 
 
-def _rounded(draw, box, radius, **kwargs):
-    draw.rounded_rectangle(box, radius=radius, **kwargs)
+def _fit_title(draw, text, max_width, max_height, max_lines=3):
+    """Largest font (76→46) where the title fits in <=max_lines and <=max_height;
+    falls back to the smallest size with an ellipsis if it still overflows."""
+    for size in range(76, 45, -3):
+        font = _font("Bold", size)
+        lines = _wrap(draw, text, font, max_width)
+        line_h = sum(font.getmetrics()) + 8
+        if len(lines) <= max_lines and len(lines) * line_h <= max_height:
+            return font, lines, line_h
+    font = _font("Bold", 46)
+    lines = _wrap(draw, text, font, max_width)
+    line_h = sum(font.getmetrics()) + 8
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        last = lines[-1]
+        while last and draw.textlength(last + "…", font=font) > max_width:
+            last = last[:-1].rstrip()
+        lines[-1] = last + "…"
+    return font, lines, line_h
 
 
-def _draw_chip(draw, x, y, text, font, *, filled):
-    """Draws a pill at (x, y); returns the x just past its right edge."""
-    pad_x, pad_y = 22, 12
-    tw = _text_w(draw, text, font)
-    ascent, descent = font.getmetrics()
-    th = ascent + descent
-    box = (x, y, x + tw + 2 * pad_x, y + th + 2 * pad_y)
-    if filled:
-        _rounded(draw, box, radius=(th + 2 * pad_y) // 2, fill=ORANGE)
-        draw.text((x + pad_x, y + pad_y), text, font=font, fill=WHITE)
-    else:
-        _rounded(draw, box, radius=(th + 2 * pad_y) // 2,
-                 fill=WHITE, outline=CHIP_BORDER, width=2)
-        draw.text((x + pad_x, y + pad_y), text, font=font, fill=INK_SOFT)
-    return box[2]
+def _waveform(draw, x, y, width, height, color, bars=80, seed=5):
+    """A fixed (deterministic) soundform — a row of rounded bars — spanning width."""
+    rng = random.Random(seed)
+    bar_w = width / (bars * 1.9)
+    gap = bar_w * 0.9
+    cx = x
+    for i in range(bars):
+        bh = height * (0.22 + 0.78 * abs(
+            0.6 * math.sin(i * 0.55) + 0.5 * math.sin(i * 0.21) + 0.3 * rng.random()))
+        bh = max(bar_w, min(height, bh))
+        draw.rounded_rectangle(
+            (cx, y + (height - bh) / 2, cx + bar_w, y + (height + bh) / 2),
+            radius=bar_w / 2, fill=color)
+        cx += bar_w + gap
 
 
-def _play_chip(draw, x, y, text, font):
-    """A duration chip with a little play triangle in front of the text."""
-    pad_x, pad_y, gap = 22, 12, 14
-    tri = 22
-    tw = _text_w(draw, text, font)
-    ascent, descent = font.getmetrics()
-    th = ascent + descent
-    box = (x, y, x + pad_x + tri + gap + tw + pad_x, y + th + 2 * pad_y)
-    _rounded(draw, box, radius=(th + 2 * pad_y) // 2,
-             fill=WHITE, outline=CHIP_BORDER, width=2)
-    cy = y + (th + 2 * pad_y) / 2
-    tx = x + pad_x
+def _play(draw, cx, cy, r, fill):
+    draw.ellipse((cx - r, cy - r, cx + r, cy + r), fill=fill)
+    s = r * 0.5
     draw.polygon(
-        [(tx, cy - tri / 2), (tx, cy + tri / 2), (tx + tri * 0.9, cy)],
-        fill=ORANGE_DEEP,
-    )
-    draw.text((tx + tri + gap, y + pad_y), text, font=font, fill=INK_SOFT)
-    return box[2]
+        [(cx - s * 0.45, cy - s), (cx - s * 0.45, cy + s), (cx + s * 0.85, cy)],
+        fill=WHITE)
 
 
-def _format_duration(seconds):
-    if not seconds:
-        return None
-    minutes = max(1, round(seconds / 60))
-    return f"{minutes} min"
-
-
-def _lesson_type_label(lesson_type):
-    return {
-        "three_words_lesson": "Vocabulary",
-        "topic": "Conversation",
-        "situation": "Conversation",
-    }.get(lesson_type)
+def _gradient_bg():
+    img = Image.new("RGB", (WIDTH, HEIGHT), BG_TOP)
+    for y in range(HEIGHT):
+        t = y / HEIGHT
+        img.paste(
+            tuple(round(BG_TOP[i] + (BG_BOTTOM[i] - BG_TOP[i]) * t) for i in range(3)),
+            (0, y, WIDTH, y + 1))
+    return img
 
 
 def render_card(view):
     """Render the OG card for a lesson view dict and return a PIL Image."""
-    img = Image.new("RGB", (WIDTH, HEIGHT), BG_TOP)
-    # Vertical cream→amber gradient.
-    top, bottom = BG_TOP, BG_BOTTOM
-    for y in range(HEIGHT):
-        t = y / HEIGHT
-        img.paste(
-            tuple(round(top[i] + (bottom[i] - top[i]) * t) for i in range(3)),
-            (0, y, WIDTH, y + 1),
-        )
+    img = _gradient_bg()
     draw = ImageDraw.Draw(img)
+    draw.rectangle((0, 0, 12, HEIGHT), fill=ORANGE)  # left brand accent
 
-    # Left brand accent bar.
-    draw.rectangle((0, 0, 12, HEIGHT), fill=ORANGE)
-
-    # --- Header: logo + wordmark (left), language pill (right) ---
-    logo_size = 92
+    # --- Header: logo + wordmark (left), "<Language> Audio Lesson" pill (right) ---
+    logo_size = 78
     try:
         logo = Image.open(_LOGO_PATH).convert("RGBA").resize((logo_size, logo_size))
         img.paste(logo, (MARGIN, MARGIN), logo)
     except OSError:
-        logo = None
-    wordmark_font = _font("ExtraBold", 44)
-    wm_x = MARGIN + logo_size + 24
-    wm_y = MARGIN + (logo_size - sum(wordmark_font.getmetrics())) // 2
-    draw.text((wm_x, wm_y), "Zeeguu", font=wordmark_font, fill=ORANGE_DEEP)
+        pass
+    wordmark = _font("ExtraBold", 38)
+    draw.text(
+        (MARGIN + logo_size + 20, MARGIN + (logo_size - sum(wordmark.getmetrics())) // 2),
+        "Zeeguu", font=wordmark, fill=ORANGE_DEEP)
 
     language = view.get("language_name")
-    if language:
-        lang_font = _font("Bold", 32)
-        lw = _text_w(draw, language, lang_font)
-        _draw_chip(draw, WIDTH - MARGIN - lw - 44, MARGIN + 20, language,
-                   lang_font, filled=True)
+    label = f"{language} Audio Lesson" if language else "Audio Lesson"
+    pill_font = _font("Bold", 34)
+    lw = draw.textlength(label, font=pill_font)
+    asc, desc = pill_font.getmetrics()
+    pill_top = MARGIN + 10
+    draw.rounded_rectangle(
+        (WIDTH - MARGIN - lw - 52, pill_top, WIDTH - MARGIN, pill_top + asc + desc + 26),
+        radius=46, fill=ORANGE)
+    draw.text((WIDTH - MARGIN - lw - 26, pill_top + 13), label, font=pill_font, fill=WHITE)
 
-    # --- Title (vertically anchored in the middle band) ---
-    title = (view.get("title") or "Audio lesson").strip()
-    title_font = _font("Bold", 62)
-    title_lines = _wrap(draw, title, title_font, WIDTH - 2 * MARGIN, max_lines=2)
-    line_h = sum(title_font.getmetrics()) + 12
-    title_y = MARGIN + logo_size + 60
-    for i, line in enumerate(title_lines):
-        draw.text((MARGIN, title_y + i * line_h), line, font=title_font, fill=INK)
+    # --- Title (hero): auto-fit, vertically centred between header and audio band ---
+    title = clean_lesson_title((view.get("title") or "Audio lesson").strip())
+    header_bottom = MARGIN + logo_size + 40
+    audio_top = HEIGHT - 150
+    font, lines, line_h = _fit_title(draw, title, WIDTH - 2 * MARGIN, audio_top - header_bottom)
+    block_h = len(lines) * line_h
+    ty = header_bottom + (audio_top - header_bottom - block_h) // 2
+    for i, line in enumerate(lines):
+        draw.text((MARGIN, ty + i * line_h), line, font=font, fill=INK)
 
-    # --- Meta chips: duration · CEFR · type ---
-    chips_y = title_y + len(title_lines) * line_h + 36
-    chip_font = _font("SemiBold", 30)
-    cursor = MARGIN
-    duration = _format_duration(view.get("duration_seconds"))
-    if duration:
-        cursor = _play_chip(draw, cursor, chips_y, duration, chip_font) + 16
-    cefr = view.get("cefr_level")
-    if cefr:
-        cursor = _draw_chip(draw, cursor, chips_y, cefr, chip_font, filled=True) + 16
-    type_label = _lesson_type_label(view.get("lesson_type"))
-    if type_label:
-        cursor = _draw_chip(draw, cursor, chips_y, type_label, chip_font, filled=False)
-
-    # --- Footer: the words being learned, else a tagline ---
-    words = [w.get("origin") for w in (view.get("words") or []) if w.get("origin")]
-    footer_font = _font("SemiBold", 30)
-    if words:
-        footer = "  ·  ".join(words[:5])
-        footer = _wrap(draw, footer, footer_font, WIDTH - 2 * MARGIN, max_lines=1)[0]
-    else:
-        footer = "Listen, and pick up the words"
-    draw.text((MARGIN, HEIGHT - MARGIN - sum(footer_font.getmetrics())),
-              footer, font=footer_font, fill=INK_SOFT)
-
-    # Bottom-right domain.
-    dom_font = _font("Bold", 28)
-    dom = "zeeguu.org"
-    draw.text((WIDTH - MARGIN - _text_w(draw, dom, dom_font),
-               HEIGHT - MARGIN - sum(dom_font.getmetrics())),
-              dom, font=dom_font, fill=ORANGE_DEEP)
+    # --- Wordless audio cue: play button + full-width soundform ---
+    by = HEIGHT - MARGIN - 46
+    _play(draw, MARGIN + 32, by + 22, 30, ORANGE_DEEP)
+    wave_x = MARGIN + 90
+    _waveform(draw, wave_x, by, WIDTH - MARGIN - wave_x, 44, ORANGE)
 
     return img
-
-
-def card_png_bytes(view):
-    from io import BytesIO
-
-    buffer = BytesIO()
-    render_card(view).save(buffer, format="PNG")
-    return buffer.getvalue()
 
 
 def cached_card_path(data_folder, lesson_id):
@@ -222,10 +179,7 @@ def cached_card_path(data_folder, lesson_id):
 
 def ensure_cached_card(view, data_folder):
     """Render (once) and cache the card PNG for this lesson; return its path.
-
-    Lessons are immutable, so an existing file is reused. Returns None if the
-    view has no lesson_id to key the cache on.
-    """
+    Returns None if the view has no lesson_id to key the cache on."""
     lesson_id = view.get("lesson_id")
     if not lesson_id:
         return None


### PR DESCRIPTION
## Why

At the size WhatsApp/iMessage render the card, the small `▶ 5 min · A1 · Conversation` chips and the footer line were **illegible and duplicated** the `og:description` text shown right below. A preview card is read in <1s at thumbnail size — only what survives shrinking belongs on it.

## What changed (card only; `og:description` unchanged)

Stripped the card to its essentials:
- **Title as hero**, auto-sized (76→46px) to fit 1–3 lines and never collide with the audio cue.
- **"<Language> Audio Lesson" pill** — states the category outright.
- Brand elephant + Zeeguu wordmark.
- A **play button + full-width soundform** as a wordless "listen" cue.

Removed from the card: the duration/level/type chips and the footer tagline — that detail already lives, legibly, in `og:description` ("*A 5-min Romanian audio lesson at level A1. Listen to a real conversation and pick up the words.*").

Also: drop the `Topic: ` / `Situation: ` prefix from the card title **and** `og:title` (`clean_lesson_title`) — it reads as clutter on a share ("Ordering coffee…" beats "Situation: Ordering coffee…").

## Deploy notes

- Cards are cached on disk per `lesson_id`. After deploy, clear the cache so existing lessons re-render with the new design:
  `rm -f $ZEEGUU_DATA_FOLDER/og-images/shared-lessons/*.png`
- WhatsApp/etc. also cache previews per URL — already-scraped links keep the old card until their cache expires; a fresh share (or `?v=2`) shows the new one immediately.

Verified by rendering long/short/x-long and a `Situation:` title via the real `render_card`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)