### PR TITLE
Daily audio: pause generation when the last lesson wasn't engaged with

### DIFF
--- a/tools/generate_daily_audio_lessons.py
+++ b/tools/generate_daily_audio_lessons.py
@@ -131,12 +131,11 @@ def generate_for_user(user, lesson_type, raw_suggestion, timezone_offset):
     """Run the full prepare+generate pipeline synchronously for one user.
     Returns one of: "generated", "exists", "skipped:<reason>", "failed:<reason>"."""
     # Pause gate (before any LLM work): skip if today's lesson already exists,
-    # or if the most recent lesson wasn't engaged with (< halfway) — we pause
-    # generation so unheard lessons don't pile up until the learner returns.
-    if generator.get_todays_lesson_for_user(user, timezone_offset).get("lesson_id"):
+    # or if generation is paused (most recent lesson not engaged with) — so
+    # unheard lessons don't pile up until the learner returns.
+    if generator.today_lesson_exists(user, timezone_offset):
         return "exists"
-    latest = DailyAudioLesson.latest_for_language(user, user.learned_language.id)
-    if latest and not latest.is_engaged:
+    if DailyAudioLesson.waiting_paused_for(user, user.learned_language.id):
         return "skipped:paused"
 
     try:
@@ -226,12 +225,11 @@ for index, user_id in enumerate(user_ids, start=1):
 
         if DRY_RUN:
             # Read-only: don't create a progress record or generate.
-            if generator.get_todays_lesson_for_user(user, timezone_offset).get("lesson_id"):
+            if generator.today_lesson_exists(user, timezone_offset):
                 output(f"{index}. {user.name} [{user.learned_language.name}] — already has today's lesson")
                 counts["exists"] += 1
                 continue
-            latest = DailyAudioLesson.latest_for_language(user, user.learned_language.id)
-            if latest and not latest.is_engaged:
+            if DailyAudioLesson.waiting_paused_for(user, user.learned_language.id):
                 output(f"{index}. {user.name} [{user.learned_language.name}] — paused (last lesson < 50% listened)")
                 counts["paused"] += 1
                 continue

--- a/tools/generate_daily_audio_lessons.py
+++ b/tools/generate_daily_audio_lessons.py
@@ -130,6 +130,15 @@ def resolve_suggestion(user, lesson_type, raw_suggestion):
 def generate_for_user(user, lesson_type, raw_suggestion, timezone_offset):
     """Run the full prepare+generate pipeline synchronously for one user.
     Returns one of: "generated", "exists", "skipped:<reason>", "failed:<reason>"."""
+    # Pause gate (before any LLM work): skip if today's lesson already exists,
+    # or if the most recent lesson wasn't engaged with (< halfway) — we pause
+    # generation so unheard lessons don't pile up until the learner returns.
+    if generator.get_todays_lesson_for_user(user, timezone_offset).get("lesson_id"):
+        return "exists"
+    latest = DailyAudioLesson.latest_for_language(user, user.learned_language.id)
+    if latest and not latest.is_engaged:
+        return "skipped:paused"
+
     try:
         canonical, is_general = resolve_suggestion(user, lesson_type, raw_suggestion)
     except ValueError as e:
@@ -217,14 +226,18 @@ for index, user_id in enumerate(user_ids, start=1):
 
         if DRY_RUN:
             # Read-only: don't create a progress record or generate.
-            existing = generator.get_todays_lesson_for_user(user, timezone_offset)
-            if existing.get("lesson_id"):
+            if generator.get_todays_lesson_for_user(user, timezone_offset).get("lesson_id"):
                 output(f"{index}. {user.name} [{user.learned_language.name}] — already has today's lesson")
                 counts["exists"] += 1
-            else:
-                output(f"{index}. {user.name} [{user.learned_language.name}] — WOULD generate {lesson_type}: {subject}")
-                counts["would-generate"] += 1
-                language_breakdown[user.learned_language.name] += 1
+                continue
+            latest = DailyAudioLesson.latest_for_language(user, user.learned_language.id)
+            if latest and not latest.is_engaged:
+                output(f"{index}. {user.name} [{user.learned_language.name}] — paused (last lesson < 50% listened)")
+                counts["paused"] += 1
+                continue
+            output(f"{index}. {user.name} [{user.learned_language.name}] — WOULD generate {lesson_type}: {subject}")
+            counts["would-generate"] += 1
+            language_breakdown[user.learned_language.name] += 1
             continue
 
         outcome = generate_for_user(user, lesson_type, raw_suggestion, timezone_offset)

--- a/zeeguu/api/endpoints/audio_lessons.py
+++ b/zeeguu/api/endpoints/audio_lessons.py
@@ -307,7 +307,10 @@ def get_todays_lesson():
     # Get timezone offset from query parameter (default to 0 for UTC)
     timezone_offset = flask.request.args.get("timezone_offset", 0, type=int)
 
-    result = generator.get_todays_lesson_for_user(user, timezone_offset)
+    # include_paused: when there's no lesson today but the last one wasn't
+    # engaged with (< halfway), surface it flagged `paused` so the app shows the
+    # waiting lesson rather than triggering a new generation.
+    result = generator.get_todays_lesson_for_user(user, timezone_offset, include_paused=True)
 
     # Check if there's a specific status code to return
     status_code = result.pop("status_code", 200)

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -673,7 +673,7 @@ class DailyLessonGenerator:
 
         return self._format_lesson_response(lesson)
 
-    def get_todays_lesson_for_user(self, user, timezone_offset=0):
+    def get_todays_lesson_for_user(self, user, timezone_offset=0, include_paused=False):
         """
         Get today's daily audio lesson for a user.
 
@@ -701,6 +701,21 @@ class DailyLessonGenerator:
         )
 
         if not lesson:
+            # No lesson today. For the app view (include_paused), if the most
+            # recent lesson wasn't engaged with (< halfway) generation is PAUSED
+            # — surface that waiting lesson flagged `paused` so the app shows it
+            # instead of making a new one. Generation callers pass the default
+            # (today-only) so a paused older lesson never blocks on-demand
+            # creation (e.g. change-topic / first day).
+            if include_paused:
+                latest = DailyAudioLesson.latest_for_language(
+                    user, user.learned_language.id
+                )
+                if latest and not latest.is_engaged:
+                    response = self._format_lesson_response(latest)
+                    if response.get("lesson_id"):
+                        response["paused"] = True
+                        return response
             return {"lesson": None, "message": "No lesson generated yet today"}
 
         return self._format_lesson_response(lesson)

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -673,6 +673,22 @@ class DailyLessonGenerator:
 
         return self._format_lesson_response(lesson)
 
+    def today_lesson_exists(self, user, timezone_offset=0):
+        """Cheap existence check for today's lesson — no response formatting,
+        word extraction, or filesystem stat. Used by the cron so it can skip a
+        user without building (and discarding) a full lesson response."""
+        start_of_today_utc, end_of_today_utc = self._get_user_day_range_utc(
+            timezone_offset
+        )
+        return (
+            DailyAudioLesson.query.with_entities(DailyAudioLesson.id)
+            .filter_by(user_id=user.id, language_id=user.learned_language.id)
+            .filter(DailyAudioLesson.created_at >= start_of_today_utc)
+            .filter(DailyAudioLesson.created_at <= end_of_today_utc)
+            .first()
+            is not None
+        )
+
     def get_todays_lesson_for_user(self, user, timezone_offset=0, include_paused=False):
         """
         Get today's daily audio lesson for a user.
@@ -708,11 +724,11 @@ class DailyLessonGenerator:
             # (today-only) so a paused older lesson never blocks on-demand
             # creation (e.g. change-topic / first day).
             if include_paused:
-                latest = DailyAudioLesson.latest_for_language(
+                paused = DailyAudioLesson.waiting_paused_for(
                     user, user.learned_language.id
                 )
-                if latest and not latest.is_engaged:
-                    response = self._format_lesson_response(latest)
+                if paused:
+                    response = self._format_lesson_response(paused)
                     if response.get("lesson_id"):
                         response["paused"] = True
                         return response

--- a/zeeguu/core/model/daily_audio_lesson.py
+++ b/zeeguu/core/model/daily_audio_lesson.py
@@ -164,6 +164,20 @@ class DailyAudioLesson(db.Model):
         completion, since a completed lesson can be replayed and paused."""
         return self.pause_position_seconds > 0
 
+    @property
+    def is_engaged(self):
+        """Did the learner get at least halfway through (or finish)?
+
+        Daily pre-generation pauses when the most recent lesson wasn't engaged
+        with, so unheard lessons don't pile up — see the daily cron and
+        get_todays_lesson_for_user.
+        """
+        if self.is_completed:
+            return True
+        if self.duration_seconds and self.pause_position_seconds:
+            return self.pause_position_seconds >= 0.5 * self.duration_seconds
+        return False
+
     def display_title(self):
         """
         Best-effort human-readable title for this lesson.
@@ -238,4 +252,13 @@ class DailyAudioLesson(db.Model):
         if not include_completed:
             query = query.filter(cls.last_completed_at.is_(None))
         return query.order_by(cls.recommended_at.desc()).first()
+
+    @classmethod
+    def latest_for_language(cls, user, language_id):
+        """Most recent lesson (any completion state) for this user + language."""
+        return (
+            cls.query.filter_by(user_id=user.id, language_id=language_id)
+            .order_by(cls.id.desc())
+            .first()
+        )
 

--- a/zeeguu/core/model/daily_audio_lesson.py
+++ b/zeeguu/core/model/daily_audio_lesson.py
@@ -164,19 +164,25 @@ class DailyAudioLesson(db.Model):
         completion, since a completed lesson can be replayed and paused."""
         return self.pause_position_seconds > 0
 
+    # Fraction of a lesson the learner must reach for it to count as "engaged".
+    # Below this, daily generation pauses so unheard lessons don't pile up.
+    ENGAGEMENT_THRESHOLD = 0.5
+
     @property
     def is_engaged(self):
         """Did the learner get at least halfway through (or finish)?
 
         Daily pre-generation pauses when the most recent lesson wasn't engaged
-        with, so unheard lessons don't pile up — see the daily cron and
+        with — see waiting_paused_for, the daily cron, and
         get_todays_lesson_for_user.
         """
         if self.is_completed:
             return True
-        if self.duration_seconds and self.pause_position_seconds:
-            return self.pause_position_seconds >= 0.5 * self.duration_seconds
-        return False
+        if not self.duration_seconds:
+            # No duration to measure against (data anomaly) — fall back to "did
+            # they start it" rather than pausing the user forever.
+            return bool(self.pause_position_seconds) or bool(self.listened_count)
+        return (self.pause_position_seconds or 0) >= self.ENGAGEMENT_THRESHOLD * self.duration_seconds
 
     def display_title(self):
         """
@@ -246,14 +252,6 @@ class DailyAudioLesson(db.Model):
         return result.canonical_suggestion if result else None
 
     @classmethod
-    def find_latest_for_user(cls, user, include_completed=False):
-        """Find the most recent audio lesson for a user"""
-        query = cls.query.filter_by(user=user)
-        if not include_completed:
-            query = query.filter(cls.last_completed_at.is_(None))
-        return query.order_by(cls.recommended_at.desc()).first()
-
-    @classmethod
     def latest_for_language(cls, user, language_id):
         """Most recent lesson (any completion state) for this user + language."""
         return (
@@ -261,4 +259,16 @@ class DailyAudioLesson(db.Model):
             .order_by(cls.id.desc())
             .first()
         )
+
+    @classmethod
+    def waiting_paused_for(cls, user, language_id):
+        """The most recent lesson when daily generation is PAUSED on it — it
+        exists but wasn't engaged with (< halfway). None when the latest was
+        engaged (or there is none), meaning generation should proceed.
+
+        Single source of truth for "is this user paused", shared by the
+        today's-lesson endpoint, the nav-dot status, and the nightly cron.
+        """
+        latest = cls.latest_for_language(user, language_id)
+        return latest if (latest and not latest.is_engaged) else None
 

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -1310,6 +1310,12 @@ class User(db.Model):
         )
 
         if not lesson:
+            # No lesson today — but if the most recent one wasn't engaged with,
+            # generation is paused and that lesson is still waiting to be played,
+            # so surface it as "ready" (the nav dot nudges the learner back).
+            latest = DailyAudioLesson.latest_for_language(self, self.learned_language_id)
+            if latest and not latest.is_engaged:
+                return "ready"
             # Check if generation is feasible before showing "available"
             if not self._is_audio_lesson_feasible():
                 return None  # Unfeasible - don't show any dot

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -1310,11 +1310,10 @@ class User(db.Model):
         )
 
         if not lesson:
-            # No lesson today — but if the most recent one wasn't engaged with,
-            # generation is paused and that lesson is still waiting to be played,
-            # so surface it as "ready" (the nav dot nudges the learner back).
-            latest = DailyAudioLesson.latest_for_language(self, self.learned_language_id)
-            if latest and not latest.is_engaged:
+            # No lesson today — but if generation is paused (latest lesson not
+            # engaged with), it's still waiting to be played, so surface it as
+            # "ready" (the nav dot nudges the learner back).
+            if DailyAudioLesson.waiting_paused_for(self, self.learned_language_id):
                 return "ready"
             # Check if generation is feasible before showing "available"
             if not self._is_audio_lesson_feasible():


### PR DESCRIPTION
Stops the nightly job piling up unheard lessons: if a learner doesn't get at least **halfway** through their most recent lesson, daily generation **pauses** until they come back and listen.

"Engaged" = completed, or `pause_position ≥ 50%` of duration — `DailyAudioLesson.is_engaged`.

## Changes
- **Cron** (`tools/generate_daily_audio_lessons.py`): per user, before any LLM work — skip if today's lesson already exists (`exists`), or if the most recent lesson isn't engaged (`paused`). Dry-run reports the paused count.
- **`get_todays_lesson_for_user(include_paused=True)`**: when there's no lesson today and the latest wasn't engaged, returns that **waiting lesson flagged `paused`** so the app shows it rather than triggering a new generation. Default stays today-only, so `prepare_lesson_generation` and on-demand creation (change-topic / first day) are unaffected.
- **`get_daily_audio_status`**: a waiting paused lesson reports as `ready`, so the nav dot keeps nudging the learner back to it.
- **Model**: `is_engaged` + `latest_for_language(user, language_id)`.

## Notes
- Backend half. The web side (paused card UI — drops the date, shows "⏸ Paused" + a "listen to resume" line) is in zeeguu/web#1149.
- Threshold (50%) lives in `is_engaged`; easy to tune.

## Test
```
source ~/code/zeeguu/api/.venv/bin/activate && python tools/generate_daily_audio_lessons.py --dry-run --user-id <id>
```
Expect a user whose last lesson is <50% listened to report `paused`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)