### PR TITLE
Daily audio: engagement uses furthest-reached, not resume pointer

### DIFF
--- a/tools/migrations/26-05-31--add_max_position_to_daily_audio_lesson.sql
+++ b/tools/migrations/26-05-31--add_max_position_to_daily_audio_lesson.sql
@@ -8,9 +8,10 @@ ALTER TABLE daily_audio_lesson
 ADD COLUMN max_position_seconds INT NOT NULL DEFAULT 0
 COMMENT 'Furthest playback position ever reached (monotonic); drives engagement, unlike the rewind-able pause_position_seconds';
 
+-- Backfill: the column is brand new (so it's 0 everywhere) — seed it from the
+-- best estimate of how far each learner got.
 UPDATE daily_audio_lesson
 SET max_position_seconds = GREATEST(
-  COALESCE(max_position_seconds, 0),
   COALESCE(pause_position_seconds, 0),
   -- A completed lesson was heard in full; credit its whole duration.
   CASE WHEN last_completed_at IS NOT NULL THEN COALESCE(duration_seconds, 0) ELSE 0 END

--- a/tools/migrations/26-05-31--add_max_position_to_daily_audio_lesson.sql
+++ b/tools/migrations/26-05-31--add_max_position_to_daily_audio_lesson.sql
@@ -1,0 +1,17 @@
+-- Engagement (is_engaged / waiting_paused_for) must measure the FURTHEST
+-- position the learner reached, not the resume pointer (pause_position_seconds),
+-- which drops when they rewind/scrub back. Add a monotonic high-water-mark.
+--
+-- Backfill existing rows from pause_position_seconds (our best estimate of how
+-- far they got) so the engagement gate doesn't regress for current lessons.
+ALTER TABLE daily_audio_lesson
+ADD COLUMN max_position_seconds INT NOT NULL DEFAULT 0
+COMMENT 'Furthest playback position ever reached (monotonic); drives engagement, unlike the rewind-able pause_position_seconds';
+
+UPDATE daily_audio_lesson
+SET max_position_seconds = GREATEST(
+  COALESCE(max_position_seconds, 0),
+  COALESCE(pause_position_seconds, 0),
+  -- A completed lesson was heard in full; credit its whole duration.
+  CASE WHEN last_completed_at IS NOT NULL THEN COALESCE(duration_seconds, 0) ELSE 0 END
+);

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -606,6 +606,7 @@ class DailyLessonGenerator:
             "created_at": lesson.created_at.isoformat() if lesson.created_at else None,
             "words": self._extract_segment_words(lesson, with_user_metadata=True),
             "pause_position_seconds": lesson.pause_position_seconds,
+            "max_position_seconds": lesson.max_position_seconds,
             "is_paused": lesson.is_paused,
             "is_completed": lesson.is_completed,
             "listened_count": lesson.listened_count,

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -974,7 +974,15 @@ class DailyLessonGenerator:
                 return {"error": "Lesson not found", "status_code": 404}
 
             action = state_data.get("action")
-            position_seconds = state_data.get("position_seconds", 0)
+            # Coerce defensively: the value comes straight from client JSON, so
+            # null / a string / a float / a negative all reach here. `.get(_, 0)`
+            # only covers a MISSING key, not an explicit null — without this an
+            # explicit null would make `pause_at` do `None > duration` → TypeError
+            # → 500, and a negative would corrupt is_paused / the resume counter.
+            try:
+                position_seconds = max(0, int(state_data.get("position_seconds") or 0))
+            except (TypeError, ValueError):
+                position_seconds = 0
 
             if action == "pause":
                 # Record pause position and time

--- a/zeeguu/core/model/daily_audio_lesson.py
+++ b/zeeguu/core/model/daily_audio_lesson.py
@@ -39,7 +39,13 @@ class DailyAudioLesson(db.Model):
 
     # Pause/resume tracking
     last_paused_at = Column(TIMESTAMP)
+    # Where to RESUME from — the last position, which can move BACKWARDS when the
+    # learner rewinds/scrubs back. Do not use this for engagement (see below).
     pause_position_seconds = Column(Integer, default=0)
+    # Furthest position ever reached, monotonic (never decreases). This is the
+    # honest "how much did they actually hear" measure. pause_position can drop
+    # below it on a rewind, which is why engagement must read THIS, not that.
+    max_position_seconds = Column(Integer, default=0)
 
     raw_suggestion = Column(db.String(128), nullable=True)
     canonical_suggestion = Column(db.String(128), nullable=True)
@@ -67,6 +73,7 @@ class DailyAudioLesson(db.Model):
         self.lesson_type = lesson_type
         self.listened_count = 0
         self.pause_position_seconds = 0
+        self.max_position_seconds = 0
         # Mint the share id up front so the client can build a share URL without
         # a round-trip — that round-trip would consume the tap's user activation
         # and break the native share sheet on iOS (it'd fall back to clipboard).
@@ -147,15 +154,21 @@ class DailyAudioLesson(db.Model):
         if self.listened_count == 0:
             self.listened_count = 1
         self.pause_position_seconds = 0
+        # Finishing means the whole thing was reached.
+        if self.duration_seconds:
+            self.max_position_seconds = max(self.max_position_seconds or 0, self.duration_seconds)
 
     def pause_at(self, position_seconds):
         """Record pause position for later resume"""
         self.last_paused_at = datetime.now()
-        # Ensure pause position doesn't exceed duration (prevents MediaSession API errors)
+        # Clamp to duration (prevents MediaSession API errors).
+        clamped = position_seconds
         if self.duration_seconds and position_seconds > self.duration_seconds:
-            self.pause_position_seconds = self.duration_seconds
-        else:
-            self.pause_position_seconds = position_seconds
+            clamped = self.duration_seconds
+        self.pause_position_seconds = clamped
+        # High-water mark: only ever grows, so a rewind-then-pause can't erase
+        # the fact that the learner already heard further. Engagement reads this.
+        self.max_position_seconds = max(self.max_position_seconds or 0, clamped)
 
     @property
     def is_completed(self):
@@ -176,17 +189,23 @@ class DailyAudioLesson(db.Model):
     def is_engaged(self):
         """Did the learner get at least halfway through (or finish)?
 
-        Daily pre-generation pauses when the most recent lesson wasn't engaged
-        with — see waiting_paused_for, the daily cron, and
+        Measured against the FURTHEST position reached (max_position_seconds),
+        not the resume pointer (pause_position_seconds) — the latter drops on a
+        rewind, which used to make someone who heard 80% then scrubbed back read
+        as "not engaged". Daily pre-generation pauses when the most recent lesson
+        wasn't engaged with — see waiting_paused_for, the daily cron, and
         get_todays_lesson_for_user.
         """
         if self.is_completed:
             return True
+        # max_position is the monotonic furthest-reached; fall back to the resume
+        # pointer for rows written before the column existed.
+        furthest = max(self.max_position_seconds or 0, self.pause_position_seconds or 0)
         if not self.duration_seconds:
             # No duration to measure against (data anomaly) — fall back to "did
             # they start it" rather than pausing the user forever.
-            return bool(self.pause_position_seconds) or bool(self.listened_count)
-        return (self.pause_position_seconds or 0) >= self.ENGAGEMENT_THRESHOLD * self.duration_seconds
+            return bool(furthest) or bool(self.listened_count)
+        return furthest >= self.ENGAGEMENT_THRESHOLD * self.duration_seconds
 
     def display_title(self):
         """

--- a/zeeguu/core/test/test_daily_audio_lesson_engagement.py
+++ b/zeeguu/core/test/test_daily_audio_lesson_engagement.py
@@ -1,0 +1,70 @@
+"""
+Engagement-gate logic for daily audio lessons (PR #646).
+
+is_engaged must measure the FURTHEST position reached (max_position_seconds),
+not the resume pointer (pause_position_seconds) which drops on a rewind. These
+are pure in-memory checks on the model — no persistence needed.
+"""
+
+from zeeguu.core.model.daily_audio_lesson import DailyAudioLesson
+from zeeguu.core.test.model_test_mixin import ModelTestMixIn
+from zeeguu.core.test.rules.user_rule import UserRule
+
+
+class DailyAudioLessonEngagementTest(ModelTestMixIn):
+    def setUp(self):
+        super().setUp()
+        user = UserRule().user
+        # 360s lesson; engagement threshold is 50% → 180s.
+        self.lesson = DailyAudioLesson(
+            user=user,
+            created_by="test",
+            duration_seconds=360,
+            language=user.learned_language,
+            lesson_type="topic",
+        )
+
+    def test_fresh_lesson_not_engaged(self):
+        assert not self.lesson.is_engaged
+
+    def test_below_half_not_engaged(self):
+        self.lesson.pause_at(108)  # 30%
+        assert self.lesson.max_position_seconds == 108
+        assert not self.lesson.is_engaged
+
+    def test_at_half_is_engaged(self):
+        self.lesson.pause_at(180)  # exactly 50%
+        assert self.lesson.is_engaged
+
+    def test_rewind_keeps_engagement(self):
+        # The bug this PR fixes: reach 80%, then scrub back and pause at 30s.
+        self.lesson.pause_at(290)  # ~80% → engaged
+        assert self.lesson.is_engaged
+        self.lesson.pause_at(30)  # rewind: resume pointer drops…
+        assert self.lesson.pause_position_seconds == 30  # …resume follows the playhead
+        assert self.lesson.max_position_seconds == 290  # …but the high-water mark holds
+        assert self.lesson.is_engaged  # still engaged — the bug would say False
+
+    def test_pause_clamps_to_duration(self):
+        self.lesson.pause_at(10_000)
+        assert self.lesson.pause_position_seconds == 360
+        assert self.lesson.max_position_seconds == 360
+
+    def test_completed_is_engaged_and_credits_full_duration(self):
+        self.lesson.mark_completed()
+        assert self.lesson.is_engaged
+        assert self.lesson.max_position_seconds == 360
+        assert self.lesson.pause_position_seconds == 0  # resume reset on completion
+
+    def test_legacy_row_falls_back_to_pause_position(self):
+        # A row written before max_position_seconds existed (backfill would set
+        # it, but simulate the in-memory fallback): only pause_position is set.
+        self.lesson.max_position_seconds = 0
+        self.lesson.pause_position_seconds = 200  # 55%
+        assert self.lesson.is_engaged
+
+    def test_no_duration_falls_back_to_started(self):
+        self.lesson.duration_seconds = None
+        assert not self.lesson.is_engaged
+        self.lesson.pause_at(5)
+        assert self.lesson.is_engaged


### PR DESCRIPTION
## Problem
`is_engaged` (which gates whether tomorrow's lesson is pre-generated) read `pause_position_seconds` — the **resume pointer**, which moves *backwards* when the learner rewinds / scrubs back to re-hear something. So a learner who listened to ~80% then jumped back to re-hear a sentence and paused there was scored on that lower position and wrongly marked **not engaged**, holding the next day's lesson.

## Fix
- New `max_position_seconds`: a monotonic high-water-mark of the furthest position ever reached.
  - `pause_at()` grows it (`max(old, clamped)`).
  - `mark_completed()` sets it to the full duration.
- `is_engaged` now measures against the furthest reached (falling back to the resume pointer for pre-migration rows). `pause_position_seconds` keeps its resume role unchanged.
- Migration adds the column and **backfills** existing rows from `pause_position_seconds` (and full duration for completed lessons) so the gate doesn't regress.
- `get_todays_lesson` response exposes `max_position_seconds` (consumed by the web "listen past halfway to unlock tomorrow" hint).

## Deploy order
1. Run migration `tools/migrations/26-05-31--add_max_position_to_daily_audio_lesson.sql`
2. Deploy this backend
3. Then the web PR (zeeguu/web#daily-audio-unlock-hint)

## Verification
Logic checked in isolation (rewind-after-80% → engaged ✅; genuine 33% → not engaged ✅; completed → engaged ✅; legacy rows → correct ✅). **Not yet run against pytest or a real DB** — reviewer should run the audio-lesson tests + apply the migration on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)