### PR TITLE
Add optional single-topic filter to the recommended feed endpoint

### DIFF
--- a/zeeguu/api/endpoints/user_articles.py
+++ b/zeeguu/api/endpoints/user_articles.py
@@ -46,6 +46,9 @@ def user_articles_recommended(count: int = 15, page: int = 0):
 
     URL parameters:
     - exclude_saved: if 'true', exclude saved articles from results
+    - topic: if given (a topic title), restrict the feed to that single topic
+      (e.g. a topic pill on the home feed). Matches the title shape returned by
+      /subscribed_topics.
 
     Note: Hidden articles are always excluded from recommendations.
     """
@@ -73,6 +76,11 @@ def user_articles_recommended(count: int = 15, page: int = 0):
 
     # Get exclusion parameters from request args
     exclude_saved = request.args.get("exclude_saved", "false").lower() == "true"
+
+    # Optional single-topic filter (e.g. a topic pill on the home feed). The
+    # value is a topic title, matching the shape returned by /subscribed_topics.
+    topic_filter = request.args.get("topic", None)
+    topics_override = [topic_filter] if topic_filter else None
 
     # Collect article IDs to exclude
     articles_to_exclude = []
@@ -111,7 +119,12 @@ def user_articles_recommended(count: int = 15, page: int = 0):
 
     try:
         content = article_recommendations_for_user(
-            user, count, page, articles_to_exclude, language=language
+            user,
+            count,
+            page,
+            articles_to_exclude,
+            language=language,
+            topics_override=topics_override,
         )
         print("Total content found: ", len(content))
     except Exception as e:
@@ -126,6 +139,18 @@ def user_articles_recommended(count: int = 15, page: int = 0):
         # Apply exclusions to the fallback query as well
         if articles_to_exclude:
             query = query.filter(Article.id.notin_(articles_to_exclude))
+
+        # Honor the single-topic filter in the fallback too, so a topic pill
+        # still narrows results when Elasticsearch is unavailable.
+        if topic_filter:
+            from zeeguu.core.model.topic import Topic
+            from zeeguu.core.model.article_topic_map import ArticleTopicMap
+
+            topic_obj = Topic.find(topic_filter)
+            if topic_obj:
+                query = query.filter(
+                    Article.topics.any(ArticleTopicMap.topic_id == topic_obj.id)
+                )
 
         content = query.order_by(Article.published_time.desc()).limit(20).all()
 

--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -110,6 +110,7 @@ def article_recommendations_for_user(
     score_threshold_for_search=5,
     maximum_added_search_articles=10,
     language=None,
+    topics_override=None,
 ):
     """
         Retrieve up to :param count + maximum_added_search_articles articles
@@ -125,6 +126,10 @@ def article_recommendations_for_user(
         Fails if no language is selected.
 
         :param articles_to_exclude: List of article IDs to exclude from results
+        :param topics_override: Optional list of topic titles. When given, the feed
+            is restricted to exactly these topics instead of the user's broader topic
+            subscriptions (e.g. a single topic pill on the home feed). The saved-search
+            augmentation is also dropped so the feed stays on the requested topic.
 
     :return:
 
@@ -140,6 +145,13 @@ def article_recommendations_for_user(
         unwanted_user_searches,
         user_ignored_sources,
     ) = _prepare_user_constraints(user, language)
+
+    if topics_override is not None:
+        # Single-topic view: pin the feed to the requested topic(s) and skip the
+        # saved-search injection below, which would otherwise mix in off-topic
+        # articles the user didn't ask for in this view.
+        topics_to_include = _topics_to_string(topics_override)
+        wanted_user_searches = ""
 
     es = Elasticsearch(ES_CONN_STRING)
 


### PR DESCRIPTION
## What

Adds an optional single-topic filter to the home feed's recommended-articles endpoint, in support of upcoming Spotify-style filter pills on the web home screen (All / one pill per subscribed topic / one pill per saved search).

## API

`GET /user_articles/recommended` (and the paginated `/<count>/<page>` variant) now accepts an optional `topic` query param:

```
GET /user_articles/recommended?topic=Technology%20%26%20Science
```

The value is a **topic title**, matching the shape returned by `/subscribed_topics` (`{id, title}`). When present, the feed is restricted to that one topic.

## How

- `article_recommendations_for_user(...)` gains a `topics_override` parameter. When set, it pins `topics_to_include` to exactly those topics (instead of the user's broader subscriptions) and drops the saved-search augmentation, so a single-topic view stays on-topic instead of mixing in off-topic saved-search matches.
- `topics_to_include` is already applied as a `must` clause in the Elasticsearch query builder, so this acts as a hard filter — no query-builder change needed.
- The DB fallback path (used when Elasticsearch is unavailable) honors the same topic filter via the `ArticleTopicMap` association, so a topic pill still narrows results during an ES outage.

## Not included

Saved-search pills on the frontend reuse the existing `/search/<term>` endpoint, so no backend change is needed for those.

## Testing notes

The recommended endpoint depends on Elasticsearch (and there are no existing tests covering it), so an automated test isn't included here. Manual verification: subscribe to several topics, hit `/user_articles/recommended?topic=<one of them>`, and confirm only that topic's articles come back; omit `topic` to get the full feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)