### PR TITLE
Crawler liveness heartbeat + route health alerts through ZeeguuMailer

### DIFF
--- a/tools/crawler_liveness_check.py
+++ b/tools/crawler_liveness_check.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""
+Crawler liveness check — a global heartbeat for the whole crawler.
+
+This is deliberately different from feed_health_check.py. That one asks
+"which INDIVIDUAL feeds have gone quiet over DAYS?" — good for spotting a single
+dead RSS source. This one asks "is the crawler, as a WHOLE, alive RIGHT NOW?":
+if NO active feed across any language has advanced in the last N hours, the
+crawler itself is down — a wedged /tmp/zeeguu-crawl.lock (see zeeguu/api#653),
+a broken deploy, an unreachable DB — and we want to know within hours, not the
+~4 days the per-feed/daily check would have taken.
+
+Alerts go out via ZeeguuMailer (the same SMTP path the API already uses for
+verification / report emails), NOT via print-to-stdout: cron jobs here run under
+run_task.sh, which redirects stdout+stderr into a log file nobody reads — which
+is exactly why feed_health_check's warnings have never reached anyone.
+
+Note on the signal: feed.last_crawled_time stores the *publish time* of the
+newest article seen for a feed (not the wall-clock crawl time), so MAX() across
+all active feeds is "newest article published anywhere." That can legitimately
+lag a few hours in quiet overnight periods, hence the generous default window —
+a real stall freezes it for days, so detection is still fast.
+
+Usage:
+    python -m tools.crawler_liveness_check [--max-age-hours N]
+"""
+import argparse
+from datetime import datetime
+
+from zeeguu.api.app import create_app_for_scripts
+from zeeguu.core.model import db, Feed
+from zeeguu.core.emailer.zeeguu_mailer import ZeeguuMailer
+
+app = create_app_for_scripts()
+app.app_context().push()
+
+# Generous on purpose: last_crawled_time tracks article publish time, which dips
+# in quiet news hours. A genuine outage freezes it for days, so 12h still catches
+# it fast while avoiding false alarms. Tighten once the real overnight low-water
+# mark is known.
+DEFAULT_MAX_AGE_HOURS = 12
+
+
+def newest_crawl_time():
+    """Most recent last_crawled_time across all active feeds — the crawler's
+    global heartbeat. None if no active feed has ever been crawled."""
+    return (
+        db.session.query(db.func.max(Feed.last_crawled_time))
+        .filter(Feed.deactivated == 0)
+        .scalar()
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Crawler global liveness heartbeat")
+    parser.add_argument(
+        "--max-age-hours",
+        type=int,
+        default=DEFAULT_MAX_AGE_HOURS,
+        help=f"Alert if no active feed has advanced within this many hours (default: {DEFAULT_MAX_AGE_HOURS})",
+    )
+    args = parser.parse_args()
+
+    newest = newest_crawl_time()
+    now = datetime.now()
+    age_hours = None if newest is None else (now - newest).total_seconds() / 3600
+
+    if age_hours is not None and age_hours < args.max_age_hours:
+        print(f"OK: newest feed crawl was {age_hours:.1f}h ago ({newest:%Y-%m-%d %H:%M}); "
+              f"under the {args.max_age_hours}h threshold.")
+        return
+
+    # --- stalled: alert via the app's own mailer ---
+    if newest is None:
+        headline = "No active feed has ever been crawled"
+    else:
+        headline = f"Newest feed crawl across ALL languages was {age_hours:.1f}h ago"
+
+    subject = "⚠️ Zeeguu crawler appears STALLED"
+    body_lines = [
+        f"The crawler liveness check failed at {now:%Y-%m-%d %H:%M}.",
+        "",
+        f"{headline} — over the {args.max_age_hours}h threshold.",
+        f"Newest last_crawled_time across active feeds: {newest}",
+        "",
+        "This points at the crawler itself being down, not just one feed:",
+        "  - a wedged crawl holding /tmp/zeeguu-crawl.lock (see zeeguu/api#653),",
+        "  - a broken deploy, or",
+        "  - the database / a downstream service being unreachable.",
+        "",
+        "Triage: ssh thor → `docker ps | grep crawler`, check /var/log/zeeguu/crawler/,",
+        "and `ps -eo pid,etime,cmd | grep crawl` for a multi-day-old stuck process.",
+    ]
+
+    print(f"ALERT: {subject} — {headline} (threshold {args.max_age_hours}h)")
+    ZeeguuMailer.send_mail(subject, body_lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/feed_health_check.py
+++ b/tools/feed_health_check.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 """
-Feed Health Check - alerts on stale or broken feeds.
+Feed Health Check - alerts on individual stale feeds (dead RSS sources).
 
-Prints warnings to stdout if issues found (for cron to email).
-Silent if everything is OK.
+Emails the report via ZeeguuMailer (the app's own SMTP) when stale feeds are
+found; silent otherwise. It used to just print to stdout "for cron to email",
+but cron jobs run under run_task.sh which swallows stdout into a log file — and
+the host MTA drops mail anyway — so those warnings never reached anyone.
+
+For "is the crawler as a whole alive right now?" see crawler_liveness_check.py.
 
 Usage:
     python -m tools.feed_health_check [--days N] [--verbose]
@@ -14,6 +18,7 @@ from datetime import datetime, timedelta
 
 from zeeguu.api.app import create_app_for_scripts
 from zeeguu.core.model import Feed
+from zeeguu.core.emailer.zeeguu_mailer import ZeeguuMailer
 
 app = create_app_for_scripts()
 app.app_context().push()
@@ -47,17 +52,25 @@ def main():
 
     stale_feeds = check_stale_feeds(args.days, args.verbose)
 
-    if stale_feeds:
-        print(f"=== STALE FEEDS (no updates in {args.days}+ days) ===\n")
-        for feed, days in stale_feeds:
-            if days is None:
-                print(f"  [{feed.language.code}] {feed.title} (id={feed.id}) - NEVER CRAWLED")
-            else:
-                print(f"  [{feed.language.code}] {feed.title} (id={feed.id}) - {days} days stale")
-                print(f"      Last crawled: {feed.last_crawled_time}")
-                if feed.url:
-                    print(f"      URL: {feed.url.as_string()}")
-            print()
+    if not stale_feeds:
+        print(f"OK: no active feed is more than {args.days} days stale.")
+        return
+
+    lines = [f"=== STALE FEEDS (no updates in {args.days}+ days) ===", ""]
+    for feed, days in stale_feeds:
+        if days is None:
+            lines.append(f"  [{feed.language.code}] {feed.title} (id={feed.id}) - NEVER CRAWLED")
+        else:
+            lines.append(f"  [{feed.language.code}] {feed.title} (id={feed.id}) - {days} days stale")
+            lines.append(f"      Last crawled: {feed.last_crawled_time}")
+            if feed.url:
+                lines.append(f"      URL: {feed.url.as_string()}")
+        lines.append("")
+
+    # Print for the run_task log (manual/debug runs) and email the report so it
+    # actually reaches a human.
+    print("\n".join(lines))
+    ZeeguuMailer.send_mail(f"⚠️ Zeeguu: {len(stale_feeds)} stale feed(s) (>{args.days}d)", lines)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Companion to #653. That PR stops the crawler from wedging; this one makes sure that **if crawling ever stops anyway, a human finds out** — which didn't happen during the 3-day outage.

## Why nothing alerted us
`feed_health_check.py` printed warnings "for cron to email." But every cron job runs under `run_task.sh`, whose final line redirects **stdout+stderr into a log file**:
```
docker compose run ... run_task python "$@" >> "$LOG_FILE" 2>&1
```
So cron never saw any output to mail. And separately, the host MTA silently drops mail anyway (`echo ... | mail ...` exits 0, nothing arrives). Two dead channels stacked — the warnings have been written to `/var/log/zeeguu/*.log` for months, unread.

## Fix: alert through the app's own SMTP
Both checks now send via **`ZeeguuMailer`** — the same path the API already uses for verification/report mail — which doesn't depend on the host MTA or on cron's stdout. (`ZeeguuMailer.send()` even auto-escalates to Sentry if the send itself fails.)

### 1. New `tools/crawler_liveness_check.py` — global heartbeat
Asks a question `feed_health_check` never did: *is the crawler, as a whole, alive right now?* If the newest `last_crawled_time` across **all** active feeds is older than `--max-age-hours` (default **12h**), it emails the team. One cheap `MAX()` query. Catches a total stall (wedged lock / bad deploy / DB down) in hours instead of the ~4 days the per-feed/daily check would've taken.

(12h default is generous on purpose: `last_crawled_time` stores article *publish* time, which dips overnight; a real outage freezes it for days, so detection is still fast. Tighten once the overnight low-water mark is known.)

### 2. `feed_health_check.py` — same mailer
Its per-feed/daily stale report now actually emails instead of vanishing into a log.

## Suggested cron (host side)
```
15 */2 * * * $RUN crawler_liveness tools/crawler_liveness_check.py
```
Every 2h. During an outage it emails each run (a persistent nag until fixed) and auto-stops when crawling resumes; state-based throttling can come later if it's noisy.

## Testing
- `py_compile` clean on both.
- `from zeeguu.core.model import db` + `db.func.max(...)` match existing patterns; `ZeeguuMailer.send_mail` is the existing report-email helper.
- Not yet run against prod DB/SMTP (needs the app env) — worth a manual `$RUN crawler_liveness ...` once to confirm the email lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)