### PR TITLE
Add article.crawled_at (ingestion timestamp) for crawler metrics

### DIFF
--- a/tools/migrations/26-06-18--add_article_crawled_at.sql
+++ b/tools/migrations/26-06-18--add_article_crawled_at.sql
@@ -1,0 +1,37 @@
+/*
+  Add article.crawled_at — the ingestion timestamp.
+
+  Why
+  ---
+  `article` only had `published_time`, which is the SOURCE's publish date and can
+  be backdated. There was no record of when WE actually crawled/inserted a row,
+  so crawler-throughput metrics ("articles ingested per hour per language") were
+  impossible — only a stale snapshot via feed.last_crawled_time. crawled_at fills
+  that gap and is the natural basis for the crawler dashboard / report digest.
+
+  Existing rows
+  -------------
+  Left NULL on purpose: we genuinely don't know when historical rows were
+  ingested, and stamping all ~4.6M of them at migration time would put a fake
+  day-0 spike into every rate chart. New rows auto-stamp via the DEFAULT below;
+  queries just treat NULL as "before we started tracking".
+
+  MySQL 5.7 notes
+  ---------------
+  - This server has no INSTANT ADD COLUMN (that's 8.0.12+), so each ALTER below
+    reorganizes the table. LOCK=NONE keeps crawl/live writes flowing, but on
+    ~4.6M rows it takes a few minutes and temp disk — run it in a low-traffic
+    window.
+  - Step 2 only attaches a DEFAULT; defaults apply to new inserts only, so the
+    existing NULLs are left untouched.
+
+  Ordering: run this BEFORE deploying the model change — the ORM maps crawled_at,
+  so it must exist on the table first.
+*/
+
+ALTER TABLE article
+    ADD COLUMN crawled_at DATETIME NULL,
+    ALGORITHM=INPLACE, LOCK=NONE;
+
+ALTER TABLE article
+    MODIFY crawled_at DATETIME NULL DEFAULT CURRENT_TIMESTAMP;

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     desc,
     Enum,
     BigInteger,
+    text,
 )
 from sqlalchemy.dialects.mysql import BIGINT
 from sqlalchemy.orm import relationship
@@ -154,6 +155,11 @@ class Article(db.Model):
     summary = Column(UnicodeText)
     word_count = Column(Integer)
     published_time = Column(DateTime)
+    # When this row was ingested by the crawler. Distinct from published_time
+    # (the source's publish date, which can be backdated) — so crawled_at is the
+    # reliable signal for crawler-throughput metrics. DB-stamped on insert; rows
+    # that predate this column are NULL.
+    crawled_at = Column(DateTime, server_default=text("CURRENT_TIMESTAMP"))
     fk_difficulty = Column(Integer)
     broken = Column(Integer)
     deleted = Column(Integer)


### PR DESCRIPTION
## Why
`article` only had `published_time` — the *source's* publish date, which can be backdated — so there was no way to know **when we actually ingested a row**. That's the missing piece for crawler-throughput metrics ("articles per hour per language"), the report digest, and the future Grafana dashboard. Today the best we have is `feed.last_crawled_time` (a stale snapshot, and itself publish-time-derived).

## What
- **Model:** `crawled_at = Column(DateTime, server_default=text("CURRENT_TIMESTAMP"))` — DB-stamped on every insert, no app code needed.
- **Migration** (`tools/migrations/26-06-18--add_article_crawled_at.sql`): adds the column **online** (`ALGORITHM=INPLACE, LOCK=NONE`).

## Decisions
- **Existing ~4.6M rows are left `NULL`** on purpose. We don't know their true ingestion time, and stamping them all at migration time would inject a fake day-0 spike into every rate chart. New rows auto-stamp; queries treat `NULL` as "before tracking started".
- **MySQL 5.7** has no `INSTANT ADD COLUMN`, so the ALTERs reorganize the table — `LOCK=NONE` keeps writes flowing, but run it in a **low-traffic window** (a few minutes + temp disk on 4.6M rows).
- **Apply the migration before deploying the model change** (the ORM maps the column, so it must exist first).

## Follow-ups this unlocks
- `articles ingested/hour/language` for the report digest and dashboard.
- A truer crawler heartbeat (`MAX(crawled_at)`) than the publish-time-based `last_crawled_time`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)