### PR TITLE
Updated User.Search to Prioritize exact match and shorter matches

### DIFF
--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -5,7 +5,7 @@ import random
 import re
 
 import sqlalchemy.orm
-from sqlalchemy import Column, Boolean, func, select
+from sqlalchemy import Column, Boolean, case, func, select
 from sqlalchemy.orm import relationship, joinedload
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -1407,12 +1407,24 @@ class User(db.Model):
             cls.username.like(f"%{escaped}%", escape="\\"),  # partial match for username
             cls.name == term,                                  # exact match for name
         ]
+        
+        # Relevance scoring: exact username match (0), prefix match (1), others (2)
+        relevance = case(
+            (cls.username == term, 0),                  # exact username match
+            (cls.username.like(f"{escaped}%", escape="\\"), 1),  # prefix match
+            else_=2,
+        )
 
         return (
             db.session.query(cls, UserAvatar)
             .select_from(cls)
             .filter(or_(*filters), cls.id != current_user_id, ~cls.email.endswith(cls.ANONYMOUS_EMAIL_DOMAIN))
             .outerjoin(UserAvatar, UserAvatar.user_id == cls.id)
+            .order_by(
+                relevance,
+                func.length(cls.username),  # shorter usernames first
+                cls.username,
+            )
             .limit(limit)
             .all()
         )

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -1407,7 +1407,7 @@ class User(db.Model):
             cls.username.like(f"%{escaped}%", escape="\\"),  # partial match for username
             cls.name == term,                                  # exact match for name
         ]
-        
+
         # Relevance scoring: exact username match (0), prefix match (1), others (2)
         relevance = case(
             (cls.username == term, 0),                  # exact username match

--- a/zeeguu/core/test/test_user_search.py
+++ b/zeeguu/core/test/test_user_search.py
@@ -1,0 +1,85 @@
+from datetime import datetime, timedelta
+
+import zeeguu.core
+import zeeguu.core.friends.listeners  # noqa: F401
+from zeeguu.core.friends.friend_streak import update_streak
+from zeeguu.core.model.friendship import Friendship
+from zeeguu.core.model.user import User
+from zeeguu.core.model.user_language import UserLanguage
+from zeeguu.core.test.model_test_mixin import ModelTestMixIn
+from zeeguu.core.test.rules.user_rule import UserRule
+
+session = zeeguu.core.model.db.session
+
+
+class UserSearchTest(ModelTestMixIn):
+    def setUp(self):
+        super().setUp()
+
+        self.searching_user = UserRule().user
+
+    def test_exact_username_match_is_ranked_first(self):
+        exact = UserRule().user
+        exact.username = "john"
+        UserRule().user.username = "johnny"
+        UserRule().user.username = "bigjohn"
+
+        session.commit()
+
+        results = User.search(self.searching_user.id, "john")
+
+        users = [user for user, avatar in results]
+
+        self.assertEqual(3, len(users))  # Ensure all three users are returned
+        self.assertEqual(exact.id, users[0].id)
+
+    def test_prefix_matches_are_ranked_before_contains_matches(self):
+        prefix = UserRule().user
+        prefix.username = "johnny"
+        contains = UserRule().user
+        contains.username = "bigjohn"
+
+        session.commit()
+
+        results = User.search(self.searching_user.id, "john")
+
+        users = [user for user, avatar in results]
+
+        self.assertEqual(2, len(users))  # Ensure all two users are returned
+        self.assertLess(
+            users.index(prefix),
+            users.index(contains),
+        )
+
+
+    def test_shorter_prefix_matches_are_ranked_first(self):
+        shorter = UserRule().user
+        shorter.username = "john1"
+        longer = UserRule().user
+        longer.username = "john123456"
+
+        session.commit()
+
+        results = User.search(self.searching_user.id, "john")
+
+        users = [user for user, avatar in results]
+
+        self.assertEqual(2, len(users))  # Ensure all two users are returned
+        self.assertLess(
+            users.index(shorter),
+            users.index(longer),
+        )
+
+    def test_current_user_is_not_returned(self):
+        self.searching_user.username = "john"
+
+        UserRule().user.username = "johnny"
+        UserRule().user.username = "bigjohn"
+        session.commit()
+
+        results = User.search(self.searching_user.id, "john")
+
+        users = [user for user, avatar in results]
+
+        self.assertNotIn(self.searching_user.id, [u.id for u in users])
+        self.assertEqual(2, len(users))  # Ensure only the other two users are returned

--- a/zeeguu/core/test/test_user_search.py
+++ b/zeeguu/core/test/test_user_search.py
@@ -19,10 +19,10 @@ class UserSearchTest(ModelTestMixIn):
         self.searching_user = UserRule().user
 
     def test_exact_username_match_is_ranked_first(self):
+        UserRule().user.username = "bigjohn"
+        UserRule().user.username = "johnny"
         exact = UserRule().user
         exact.username = "john"
-        UserRule().user.username = "johnny"
-        UserRule().user.username = "bigjohn"
 
         session.commit()
 
@@ -34,10 +34,10 @@ class UserSearchTest(ModelTestMixIn):
         self.assertEqual(exact.id, users[0].id)
 
     def test_prefix_matches_are_ranked_before_contains_matches(self):
-        prefix = UserRule().user
-        prefix.username = "johnny"
         contains = UserRule().user
         contains.username = "bigjohn"
+        prefix = UserRule().user
+        prefix.username = "johnny"
 
         session.commit()
 
@@ -53,10 +53,11 @@ class UserSearchTest(ModelTestMixIn):
 
 
     def test_shorter_prefix_matches_are_ranked_first(self):
-        shorter = UserRule().user
-        shorter.username = "john1"
+        # Add longer first so that we can test that the shorter one is ranked first after search
         longer = UserRule().user
         longer.username = "john123456"
+        shorter = UserRule().user
+        shorter.username = "john1"
 
         session.commit()
 
@@ -69,6 +70,38 @@ class UserSearchTest(ModelTestMixIn):
             users.index(shorter),
             users.index(longer),
         )
+
+    def test_shorter_prefix_matches_are_ranked_first_v2(self):
+        longer = UserRule().user
+        longer.username = "witty_beaver123456"
+        shorter1 = UserRule().user
+        shorter1.username = "witty_beaver1"
+        shorter0 = UserRule().user
+        shorter0.username = "witty_beaver0"
+
+
+        session.commit()
+
+        results = User.search(self.searching_user.id, "witty_beaver")
+
+        users = [user for user, avatar in results]
+
+        self.assertEqual(3, len(users))  # Ensure all three users are returned
+        self.assertLess(
+            users.index(shorter0),
+            users.index(longer),
+        )
+        self.assertLess(
+            users.index(shorter1),
+            users.index(longer),
+        )
+
+        self.assertLess(
+            users.index(shorter0),
+            users.index(shorter1),
+        )
+        
+
 
     def test_current_user_is_not_returned(self):
         self.searching_user.username = "john"


### PR DESCRIPTION
Updated the search function to order by (in priority)

1. Exact match
2. prefix match
3. username length

Also created tests to confirm this behavior in test_user_search.py
