### PR TITLE
Fix dead LLM model in reader translation; centralize model IDs

### DIFF
--- a/zeeguu/core/llm_services/anthropic_service.py
+++ b/zeeguu/core/llm_services/anthropic_service.py
@@ -8,6 +8,7 @@ from typing import List, Dict, Optional
 
 from .llm_service import LLMService
 from .prompts import format_prompt, PROMPT_VERSION_V3
+from zeeguu.core.llm_services import models
 from zeeguu.logging import log
 
 
@@ -26,8 +27,7 @@ class AnthropicService(LLMService):
         try:
             import anthropic
             self.client = anthropic.Anthropic(api_key=self.api_key, timeout=self.timeout)
-            # Use Claude Sonnet 4.5 (latest model as of September 2025)
-            self.model = "claude-sonnet-4-5-20250929"
+            self.model = models.ANTHROPIC_GENERAL
         except ImportError:
             raise ImportError("anthropic package not installed. Run: pip install anthropic")
     

--- a/zeeguu/core/llm_services/deepseek_service.py
+++ b/zeeguu/core/llm_services/deepseek_service.py
@@ -9,6 +9,7 @@ from typing import List, Dict, Optional
 
 from .llm_service import LLMService
 from .prompts import format_prompt, PROMPT_VERSION_V3
+from zeeguu.core.llm_services import models
 from zeeguu.logging import log
 
 
@@ -21,7 +22,7 @@ class DeepSeekService(LLMService):
             raise ValueError("DEEPSEEK_API_KEY environment variable not set")
 
         self.base_url = "https://api.deepseek.com/v1"
-        self.model = "deepseek-chat"
+        self.model = models.DEEPSEEK_GENERAL
         # Set timeout (default 120 seconds = 2 minutes)
         self.timeout = timeout
 

--- a/zeeguu/core/llm_services/grammar_correction_service.py
+++ b/zeeguu/core/llm_services/grammar_correction_service.py
@@ -12,10 +12,11 @@ import time
 from zeeguu.logging import log
 from .haiku_client import HAIKU_MODEL, haiku_completion_or_raise
 from .prompts.grammar_correction import get_full_article_correction_prompt
+from zeeguu.core.llm_services import models
 
 # Model names for tracking
-ANTHROPIC_CORRECTION_MODEL = HAIKU_MODEL
-DEEPSEEK_CORRECTION_MODEL = "deepseek-chat"
+ANTHROPIC_CORRECTION_MODEL = models.GRAMMAR_CORRECTION_ANTHROPIC
+DEEPSEEK_CORRECTION_MODEL = models.GRAMMAR_CORRECTION_DEEPSEEK
 
 
 class GrammarCorrectionService:

--- a/zeeguu/core/llm_services/haiku_client.py
+++ b/zeeguu/core/llm_services/haiku_client.py
@@ -19,8 +19,9 @@ from typing import Optional
 
 import requests
 from zeeguu.logging import log
+from zeeguu.core.llm_services import models
 
-HAIKU_MODEL = "claude-haiku-4-5-20251001"
+HAIKU_MODEL = models.ANTHROPIC_HAIKU
 ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
 

--- a/zeeguu/core/llm_services/models.py
+++ b/zeeguu/core/llm_services/models.py
@@ -1,0 +1,56 @@
+"""
+Central registry of every LLM model Zeeguu talks to.
+
+Single source of truth: this is the only place raw model-ID strings should
+live. Call sites import a *role* constant (e.g. ``WORD_TRANSLATION``) instead of
+hardcoding a dated snapshot. When a provider retires a snapshot, we change one
+line here instead of grepping the whole codebase.
+
+This exists because of a concrete outage: ``claude-sonnet-4-20250514`` was
+hardcoded in the reader's translation path, Anthropic stopped serving that
+snapshot (404 ``not_found_error``), and the "Ask LLM" action silently failed
+("Ask LLM — try again") with no single place to fix it. Grouping by role rather
+than by vendor keeps "what model runs where" readable at a glance and makes
+re-pointing a feature to a cheaper/faster tier a one-line edit.
+
+Model IDs are authoritative as of 2026-07. See
+https://platform.claude.com/docs/en/about-claude/models/overview for current IDs.
+"""
+
+# --- Canonical model IDs — the ONLY place a raw model string appears ---
+ANTHROPIC_SONNET = "claude-sonnet-4-5-20250929"  # current Sonnet tier
+ANTHROPIC_HAIKU = "claude-haiku-4-5-20251001"    # current Haiku (fast / cheap)
+DEEPSEEK_CHAT = "deepseek-chat"
+
+# --- Roles → model. Change the right-hand side to re-point a feature. ---
+
+# Reader "Ask LLM" on-demand single word/phrase translation (ADR 022) and
+# separated-MWE translation. Both are gated behind a user click, so a cheaper
+# tier (ANTHROPIC_HAIKU) would be a reasonable cost cut; kept on Sonnet to
+# preserve the behaviour these paths had before the outage.
+WORD_TRANSLATION = ANTHROPIC_SONNET
+MWE_TRANSLATION = ANTHROPIC_SONNET
+
+# Multi-word-expression detection during article tokenization.
+MWE_DETECTION = ANTHROPIC_SONNET
+
+# Translation validation / provider-agreement checks before exercises.
+TRANSLATION_VALIDATION = ANTHROPIC_SONNET
+
+# Meaning-frequency classification (COMMON / RARE / …). NOTE: also used as the
+# DB lookup key in AiGenerator.get_current_classification_model — keep the model
+# a classification run records and the model looked up in sync via this one constant.
+MEANING_FREQUENCY = ANTHROPIC_SONNET
+
+# General-purpose Anthropic SDK service (background example / text generation).
+ANTHROPIC_GENERAL = ANTHROPIC_SONNET
+
+# Article simplification + CEFR classification (real-time Haiku key path).
+SIMPLIFICATION = ANTHROPIC_HAIKU
+
+# Grammar / spelling correction of simplified text (provider-selectable).
+GRAMMAR_CORRECTION_ANTHROPIC = ANTHROPIC_HAIKU
+GRAMMAR_CORRECTION_DEEPSEEK = DEEPSEEK_CHAT
+
+# DeepSeek general chat (simplification + its fallback path).
+DEEPSEEK_GENERAL = DEEPSEEK_CHAT

--- a/zeeguu/core/llm_services/mwe_translation_service.py
+++ b/zeeguu/core/llm_services/mwe_translation_service.py
@@ -22,6 +22,8 @@ import json
 import logging
 from typing import Optional
 
+from zeeguu.core.llm_services import models
+
 logger = logging.getLogger(__name__)
 
 # Language code to name mapping
@@ -102,7 +104,7 @@ def translate_word_in_context(
         client = anthropic.Anthropic(api_key=api_key, timeout=timeout)
 
         response = client.messages.create(
-            model="claude-sonnet-4-20250514",
+            model=models.WORD_TRANSLATION,
             max_tokens=50,
             temperature=0.1,
             messages=[{"role": "user", "content": prompt}],
@@ -160,7 +162,7 @@ def translate_separated_mwe(
         client = anthropic.Anthropic(api_key=api_key, timeout=timeout)
 
         response = client.messages.create(
-            model="claude-sonnet-4-20250514",  # Fast model for translation
+            model=models.MWE_TRANSLATION,
             max_tokens=50,  # Short response expected
             temperature=0.1,  # Low temperature for consistent translation
             messages=[{"role": "user", "content": prompt}]
@@ -232,7 +234,7 @@ JSON:"""
         client = anthropic.Anthropic(api_key=api_key, timeout=timeout)
 
         response = client.messages.create(
-            model="claude-sonnet-4-20250514",
+            model=models.MWE_TRANSLATION,
             max_tokens=200,
             temperature=0.1,
             messages=[{"role": "user", "content": prompt}]

--- a/zeeguu/core/llm_services/simplification_and_classification.py
+++ b/zeeguu/core/llm_services/simplification_and_classification.py
@@ -17,6 +17,7 @@ from zeeguu.core.model.article import Article
 from zeeguu.core.model.url import Url
 from .haiku_client import HAIKU_MODEL, haiku_completion_or_raise
 from .prompts.article_simplification import get_adaptive_simplification_prompt
+from zeeguu.core.llm_services import models
 
 
 # Round-robin counter for alternating between providers
@@ -79,7 +80,7 @@ def simplify_article_adaptive_levels(
     title: str,
     content: str,
     target_language: str,
-    model: str = "deepseek-chat",
+    model: str = models.DEEPSEEK_GENERAL,
     simplification_provider: str = None,
     correct_grammar: bool = False,
 ) -> dict:
@@ -152,7 +153,7 @@ def simplify_article_adaptive_levels(
         api_start_time = time.time()
 
         if provider == "deepseek":
-            model_name = "deepseek-chat"
+            model_name = models.DEEPSEEK_GENERAL
             log(f"  Sending request to DeepSeek API...")
             response = requests.post(
                 "https://api.deepseek.com/v1/chat/completions",
@@ -835,7 +836,7 @@ def create_user_specific_simplified_version(session, article, target_level):
             simplified_content=simplified_content["content"],
             simplified_summary=simplified_content.get("summary", ""),
             cefr_level=target_level,
-            ai_model="claude-3-5-sonnet",  # Match what SimplificationService actually uses
+            ai_model=models.SIMPLIFICATION,  # provenance: primary model SimplificationService uses (Haiku; DeepSeek fallback)
             commit=True,
         )
 
@@ -894,7 +895,7 @@ def create_simplified_version_from_upload(session, upload, target_level):
             simplified_content=result["content"],
             simplified_summary=result.get("summary", ""),
             cefr_level=target_level,
-            ai_model="claude-3-5-sonnet",
+            ai_model=models.SIMPLIFICATION,  # provenance: primary model SimplificationService uses (Haiku; DeepSeek fallback)
             commit=True,
         )
     except Exception as e:

--- a/zeeguu/core/llm_services/simplification_service.py
+++ b/zeeguu/core/llm_services/simplification_service.py
@@ -7,6 +7,7 @@ import requests
 from typing import Dict, Optional, Tuple
 from zeeguu.logging import log
 from zeeguu.core.llm_services.haiku_client import haiku_completion
+from zeeguu.core.llm_services import models
 
 
 class SimplificationService:
@@ -397,7 +398,7 @@ TOPIC: [topic]"""
                     "Content-Type": "application/json",
                 },
                 json={
-                    "model": "deepseek-chat",
+                    "model": models.DEEPSEEK_GENERAL,
                     "messages": [{"role": "user", "content": prompt}],
                     "max_tokens": 30,
                     "temperature": 0.1,
@@ -518,7 +519,7 @@ IMPORTANT:
             
             # Create the payload with proper JSON encoding
             payload = {
-                "model": "claude-haiku-4-5-20251001",
+                "model": models.SIMPLIFICATION,
                 "max_tokens": 4000,
                 "temperature": 0.3,
                 "messages": [{"role": "user", "content": prompt}],
@@ -631,7 +632,7 @@ IMPORTANT: Summary should be concise, maximum 25 words, using {target_level} voc
                     "Content-Type": "application/json",
                 },
                 json={
-                    "model": "deepseek-chat",
+                    "model": models.DEEPSEEK_GENERAL,
                     "messages": [{"role": "user", "content": prompt}],
                     "max_tokens": 8000,
                     "temperature": 0.3,
@@ -820,7 +821,7 @@ Remember: Keep the same factual information but make it appropriate for {target_
                     "Content-Type": "application/json",
                 },
                 json={
-                    "model": "deepseek-chat",
+                    "model": models.DEEPSEEK_GENERAL,
                     "messages": [{"role": "user", "content": prompt}],
                     "max_tokens": 2000,
                     "temperature": 0.3,

--- a/zeeguu/core/llm_services/translation_validator.py
+++ b/zeeguu/core/llm_services/translation_validator.py
@@ -31,6 +31,7 @@ from typing import Optional, List
 
 from zeeguu.logging import log
 from zeeguu.core.model.language import Language
+from zeeguu.core.llm_services import models
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,7 @@ class ValidationResult:
 class TranslationValidator:
     """Validates and classifies translations before they enter exercises."""
 
-    MODEL_NAME = "claude-sonnet-4-5-20250929"
+    MODEL_NAME = models.TRANSLATION_VALIDATION
 
     def __init__(self):
         """Initialize with Anthropic client."""

--- a/zeeguu/core/model/ai_generator.py
+++ b/zeeguu/core/model/ai_generator.py
@@ -5,6 +5,7 @@ AI Model entity for tracking which AI models were used for various tasks.
 from datetime import datetime
 from sqlalchemy import Column, Integer, String, Text, DateTime
 from zeeguu.core.model.db import db
+from zeeguu.core.llm_services import models
 
 
 class AIGenerator(db.Model):
@@ -68,4 +69,4 @@ class AIGenerator(db.Model):
     @classmethod
     def get_current_classification_model(cls):
         """Get the current model used for meaning frequency classification."""
-        return cls.query.filter_by(model_name="claude-sonnet-4-5-20250929").first()
+        return cls.query.filter_by(model_name=models.MEANING_FREQUENCY).first()

--- a/zeeguu/core/model/meaning_frequency_classifier.py
+++ b/zeeguu/core/model/meaning_frequency_classifier.py
@@ -12,13 +12,14 @@ from zeeguu.core.llm_services.prompts.meaning_frequency_classifier import (
 )
 from zeeguu.core.model.meaning import MeaningFrequency
 from zeeguu.core.model.meaning import PhraseType
+from zeeguu.core.llm_services import models
 from zeeguu.logging import log
 
 
 class MeaningFrequencyClassifier:
     """Classifies meaning frequencies using Claude API."""
 
-    MODEL_NAME = "claude-sonnet-4-5-20250929"  # Latest model (September 2025)
+    MODEL_NAME = models.MEANING_FREQUENCY
 
     def __init__(self):
         """Initialize with Anthropic client."""

--- a/zeeguu/core/mwe/llm_mwe_detector.py
+++ b/zeeguu/core/mwe/llm_mwe_detector.py
@@ -21,6 +21,8 @@ import re
 from typing import List, Dict, Optional
 from threading import Lock
 
+from zeeguu.core.llm_services import models
+
 logger = logging.getLogger(__name__)
 
 # Language names for prompts
@@ -178,7 +180,7 @@ JSON:"""
 
         try:
             response = self.client.messages.create(
-                model="claude-sonnet-4-20250514",
+                model=models.MWE_DETECTION,
                 max_tokens=500,
                 messages=[{"role": "user", "content": prompt}]
             )
@@ -448,7 +450,7 @@ JSON:"""
         # Single LLM call for all sentences
         try:
             response = self.client.messages.create(
-                model="claude-sonnet-4-20250514",
+                model=models.MWE_DETECTION,
                 max_tokens=2000,
                 messages=[{"role": "user", "content": prompt}]
             )


### PR DESCRIPTION
## Why

A user hit **"Ask LLM — try again"** on a Danish translation (`slå ihjel`). Prod logs (`journalctl -t zeeguu-api`) showed the real cause:

```
HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 404 Not Found"
ERROR LLM word translation failed for 'slå ihjel': Error code: 404 -
  {'type': 'not_found_error', 'message': 'model: claude-sonnet-4-20250514'}
POST /ask_llm_translation/da/en  →  404
```

Anthropic has retired the `claude-sonnet-4-20250514` snapshot. `translate_with_llm()` caught the exception and returned `None`, so `/ask_llm_translation` returned its own `404 "LLM translation failed"`, which the reader renders as "Ask LLM — try again". The same dead ID was also hardcoded in the MWE detector.

## What

- **Root-cause fix:** the two dead-model call sites now use the current Sonnet (`claude-sonnet-4-5-20250929`) — the same live model the translation-validator path already uses successfully in prod.
- **New `zeeguu/core/llm_services/models.py`:** single source of truth for every model ID we call, grouped by **role** (`WORD_TRANSLATION`, `MWE_DETECTION`, `SIMPLIFICATION`, …) with canonical vendor IDs in one place. Retiring a snapshot is now a one-line edit instead of a codebase-wide grep. Every live model string across the LLM services (Anthropic / DeepSeek / Haiku) now imports from it, and `AiGenerator`'s classification-model DB lookup shares the same constant so recorded ↔ looked-up model stay in sync.
- **Provenance fix:** simplified articles were stamped `ai_model="claude-3-5-sonnet"` while `SimplificationService` actually runs Haiku 4.5 — the exact mislabel the [LLM-output-provenance pattern](https://patterns.mircealungu.com/llm-output-provenance/) warns about. Now stamped from `models.SIMPLIFICATION`.

## Notes

- Reader-facing translations (`WORD_TRANSLATION` / `MWE_TRANSLATION`) are kept on **Sonnet** to match prior behaviour; they're click-gated (ADR 022), so switching them to `ANTHROPIC_HAIKU` for cost is now a one-line change.
- No behaviour change beyond the model swap; all touched modules compile and the reader translation import chain loads clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)