### PR TITLE
Fix truncated translate-and-adapt; route through shared Haiku client

### DIFF
--- a/zeeguu/api/endpoints/article_upload.py
+++ b/zeeguu/api/endpoints/article_upload.py
@@ -208,7 +208,17 @@ def article_upload_translate_and_adapt(upload_id):
         target_level=user_level,
     )
     if not result:
-        flask.abort(500, "Translation failed")
+        # translate_and_adapt returns None when the LLM output is truncated at
+        # the token cap as well as on genuine API errors. The most common cause
+        # for a user-submitted piece is that it's simply too long to translate
+        # in one pass, so give an actionable hint rather than a bare "failed".
+        # 422 (not 500) — oversized content is a content issue, not a server
+        # fault, and shouldn't page on-call.
+        flask.abort(
+            422,
+            "Could not translate this article. It may be too long to process in "
+            "one piece — try importing a single chapter.",
+        )
 
     translated_url = Url.find_or_create(db_session, translated_url_key)
     target_lang_obj = Language.find(target_language)

--- a/zeeguu/core/llm_services/haiku_client.py
+++ b/zeeguu/core/llm_services/haiku_client.py
@@ -63,7 +63,16 @@ def haiku_completion(
         if response.status_code != 200:
             log(f"Anthropic API error: {response.status_code}")
             return None
-        return response.json()["content"][0]["text"]
+        data = response.json()
+        # stop_reason "max_tokens" means the reply was cut off at the cap — the
+        # text is incomplete and any caller parsing it (JSON, structured fields)
+        # gets garbage. Treat truncation as a failure so callers fall back or
+        # surface an error instead of promoting a half-finished result. Callers
+        # that need longer output should raise max_tokens.
+        if data.get("stop_reason") == "max_tokens":
+            log(f"Haiku output truncated at max_tokens={max_tokens}")
+            return None
+        return data["content"][0]["text"]
     except Exception as e:
         log(f"Haiku completion failed: {e}")
         return None
@@ -84,4 +93,10 @@ def haiku_completion_or_raise(
         raise Exception(
             f"Anthropic API error: {response.status_code} - {response.text}"
         )
+    # NOTE: deliberately does NOT treat stop_reason "max_tokens" as an error.
+    # The fail-soft haiku_completion does (truncation -> None -> fallback), but
+    # the batch crawl simplification pipeline calls this variant and has long
+    # inputs that can legitimately hit the cap; raising here would turn stored
+    # (truncated) simplifications into pipeline failures and shrink feed
+    # inventory. Left as-is on purpose — revisit alongside the chunking work.
     return response.json()["content"][0]["text"]

--- a/zeeguu/core/llm_services/simplification_service.py
+++ b/zeeguu/core/llm_services/simplification_service.py
@@ -514,73 +514,52 @@ IMPORTANT:
 
         log(f"Prompt length: {len(prompt)} chars")
 
+        # Route through the shared Haiku client so the model (models.SIMPLIFICATION,
+        # via haiku_client), key, endpoint, and truncation handling live in one
+        # place instead of a second hand-rolled copy here.
+        #
+        # max_tokens must leave room for the *translated* output, which for a full
+        # chapter runs at least as long as the input (German et al. run 20-30%
+        # longer). Haiku 4.5's ceiling is 64k, so 16k comfortably covers a single
+        # chapter (~4k words). If the model still hits the cap, haiku_completion
+        # returns None (it treats stop_reason "max_tokens" as a failure) rather
+        # than handing back truncated, unparseable JSON.
+        result_text = haiku_completion(
+            prompt, max_tokens=16000, temperature=0.3, timeout=120
+        )
+        if not result_text:
+            return None
+
         try:
+            import re
             import json
-            
-            # Create the payload with proper JSON encoding
-            payload = {
-                "model": models.SIMPLIFICATION,
-                "max_tokens": 4000,
-                "temperature": 0.3,
-                "messages": [{"role": "user", "content": prompt}],
-            }
-            
-            # Manually serialize to JSON to handle encoding issues
-            json_payload = json.dumps(payload, ensure_ascii=False)
-            
-            response = requests.post(
-                "https://api.anthropic.com/v1/messages",
-                headers={
-                    "x-api-key": self.anthropic_api_key,
-                    "anthropic-version": "2023-06-01",
-                    "content-type": "application/json; charset=utf-8",
-                },
-                data=json_payload.encode('utf-8'),  # Explicitly encode as UTF-8
-                timeout=60,
-            )
+            import markdown2
 
-            if response.status_code == 200:
-                result_text = response.json()["content"][0]["text"]
-                
-                # Clean up markdown code blocks if present
-                import re
-                if result_text.startswith("```"):
-                    # Remove markdown code blocks
-                    result_text = re.sub(r'^```(?:json)?\n', '', result_text)
-                    result_text = re.sub(r'\n```$', '', result_text)
-                    result_text = result_text.strip()
-                
-                # Parse JSON response
-                import json
-                import markdown2
-                try:
-                    # LLMs often return JSON with literal newlines inside
-                    # string values (instead of \n), which strict JSON rejects
-                    result = json.loads(result_text, strict=False)
-                    
-                    # Convert markdown content to HTML
-                    if "content" in result and result["content"]:
-                        result["content"] = markdown2.markdown(
-                            result["content"],
-                            extras=['break-on-newline', 'fenced-code-blocks', 'tables']
-                        )
-                    
-                    # Add fallback summary if not provided by LLM
-                    if "summary" not in result or not result["summary"]:
-                        from bs4 import BeautifulSoup
-                        clean_content = BeautifulSoup(result["content"], 'html.parser').get_text()
-                        result["summary"] = clean_content[:200] + "..."
-                    return result
-                except json.JSONDecodeError as e:
-                    log(f"Error parsing Anthropic JSON: {e}")
-                    log(f"Problematic JSON response: {result_text}")
-                    return None
-            else:
-                log(f"Anthropic API error: {response.status_code}")
-                log(f"Response text: {response.text}")
-                log(f"Content length: {len(content)} characters")
-                return None
+            # Strip a ```json ... ``` fence if the model wrapped its reply.
+            if result_text.startswith("```"):
+                result_text = re.sub(r'^```(?:json)?\n', '', result_text)
+                result_text = re.sub(r'\n```$', '', result_text)
+                result_text = result_text.strip()
 
+            # LLMs often return JSON with literal newlines inside string values
+            # (instead of \n), which strict JSON rejects.
+            result = json.loads(result_text, strict=False)
+
+            if "content" in result and result["content"]:
+                result["content"] = markdown2.markdown(
+                    result["content"],
+                    extras=['break-on-newline', 'fenced-code-blocks', 'tables']
+                )
+
+            if "summary" not in result or not result["summary"]:
+                from bs4 import BeautifulSoup
+                clean_content = BeautifulSoup(result["content"], 'html.parser').get_text()
+                result["summary"] = clean_content[:200] + "..."
+            return result
+        except json.JSONDecodeError as e:
+            log(f"Error parsing Anthropic JSON: {e}")
+            log(f"Problematic JSON response: {result_text}")
+            return None
         except Exception as e:
             log(f"Error in Anthropic translation: {e}")
             return None
@@ -634,18 +613,33 @@ IMPORTANT: Summary should be concise, maximum 25 words, using {target_level} voc
                 json={
                     "model": models.DEEPSEEK_GENERAL,
                     "messages": [{"role": "user", "content": prompt}],
-                    "max_tokens": 8000,
+                    # deepseek-chat caps max_tokens at 8192 (unlike Haiku's 64k);
+                    # requesting more is rejected with a 400. 8192 is the most
+                    # headroom available — anything longer is caught by the
+                    # finish_reason check below rather than truncated silently.
+                    "max_tokens": 8192,
                     "temperature": 0.3,
                 },
-                timeout=60,
+                timeout=120,
             )
 
             if response.status_code == 200:
                 try:
                     response_data = response.json()
-                    result_text = response_data["choices"][0]["message"]["content"]
+                    choice = response_data["choices"][0]
+                    result_text = choice["message"]["content"]
                     log(f"DeepSeek raw response: {result_text[:200]}...")
-                    
+
+                    # finish_reason "length" is DeepSeek's truncation signal (the
+                    # equivalent of Anthropic's stop_reason "max_tokens"). Bail
+                    # rather than parse a cut-off response.
+                    if choice.get("finish_reason") == "length":
+                        log(
+                            f"DeepSeek translation hit the token cap "
+                            f"(finish_reason=length, input {len(content)} chars)"
+                        )
+                        return None
+
                     # Clean up markdown code blocks if present
                     import re
                     if result_text.startswith("```"):


### PR DESCRIPTION
## Problem

A user tried to import a fanfiction chapter (`The Changing of the Guard`, ~4k words / 24k chars) via *translate-and-adapt* (English → German B2) and it failed. Server logs showed the Anthropic call returning `Error parsing Anthropic JSON: Unterminated string` — the LLM reply was **cut off at `max_tokens`** mid-JSON, then fell back to DeepSeek (also capped) and produced a broken/incomplete article.

Root cause: not a length *limit* and not abuse — the output caps (`max_tokens=4000` Anthropic, `8000` DeepSeek) were too small for a full chapter's translation, which runs at least as long as the input. There was no truncation detection, so a cut-off reply became unparseable JSON.

## Changes

- **Raise the Anthropic cap to 16000** (Haiku 4.5's output ceiling is 64k) and **route the call through the shared `haiku_client`** instead of a duplicated hand-rolled `requests.post` — model (`models.SIMPLIFICATION`), key, endpoint, and truncation handling now live in one place. Removes ~40 lines of duplication.
- **Detect truncation in `haiku_completion`** (`stop_reason == "max_tokens"` → `None`, fail-soft) so a cut-off reply becomes a clean fallback/failure instead of garbage JSON. Left `haiku_completion_or_raise` (the batch crawl path) **unchanged** on purpose — long crawled articles can legitimately hit the cap there, and raising would shrink simplified-article inventory.
- **DeepSeek**: raise to its **8192** ceiling (16000 would 400) and detect `finish_reason == "length"`.
- **Endpoint**: return **422 with an actionable message** ("try importing a single chapter") instead of an opaque `500 "Translation failed"`.

The reported chapter should now translate on the primary Anthropic path (16k leaves ample room). The truncation detection is the safety net for genuinely huge single chapters.

## Not included / follow-up

- **Chunking** long works into per-chapter LLM calls is the durable fix for arbitrarily long content — tracked separately.
- A weekly per-user character cooldown (the original idea) is **not** needed: this was a truncation bug on a normal-sized chapter, not a cost/abuse problem. It pairs naturally with chunking later, if wanted.

## Testing

Import + wiring smoke-tested (`HAIKU_MODEL` resolves via `models.ANTHROPIC_HAIKU`). No automated tests cover these methods (they call live LLM APIs). Recommend re-importing the fanfiction URL to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)