### PR TITLE
stanza_service: finer histogram buckets where the data lives

### DIFF
--- a/stanza_service/app.py
+++ b/stanza_service/app.py
@@ -25,9 +25,12 @@ import stanza
 _stats_lock = threading.Lock()
 
 # Latency histogram buckets (seconds), Prometheus-style cumulative "le" buckets.
-# Fine-grained below 1s (where ~99% of tokenizations land) with tail coverage to
-# 60s: measured p99.9 is ~5s and the legitimate slow tail reaches ~12s.
-DURATION_BUCKETS = [0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0, 30.0, 60.0]
+# Boundaries placed from observed data (Grafana), not guesswork: live tokenizes
+# cluster in 1-2s and crawl (big-text batches) in 5-15s, so both regions get
+# dense resolution. Too-coarse buckets there made histogram_quantile interpolate
+# the wide gaps, pinning every percentile to a bucket edge (e.g. p50/p90/p99 all
+# stuck at 1.50/1.90/1.99 when everything sat in a single [1,2] bucket).
+DURATION_BUCKETS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5, 6, 8, 10, 12, 15, 20, 30, 60]
 
 _request_stats = {
     "total_requests": 0,


### PR DESCRIPTION
The tokenize-latency histogram's initial buckets (`…1, 2, 5, 10…`) turned out too coarse exactly where the traffic sits. Grafana (after #663 deployed) showed:
- **live** `stanza:5001` tokenizes all land in **[1,2]s**
- **crawl** `stanza_crawl:5001` batches land in **[5,15]s**

With no bucket boundaries inside those ranges, `histogram_quantile` just interpolates the wide gaps and **pins every percentile to a bucket edge** — live p50/p90/p99 were stuck at **1.50 / 1.90 / 1.99** regardless of real latency, and crawl p99 hugged 10. The lines were reporting bucket geometry, not latency.

New buckets add resolution in both hot regions:
```python
DURATION_BUCKETS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5, 6, 8, 10, 12, 15, 20, 30, 60]
```

20 integer counters per worker — negligible cost. After deploy (stanza recreate), the percentile lines become real numbers.

Note: existing histogram data keeps its old bucket boundaries; the new ones take effect for samples recorded after the recreate (a brief discontinuity in the bucketed series, expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)