### PR TITLE
stanza_service: pin stanza==1.11.0 to fix DA depparse 500s (slow feed)

### DIFF
--- a/stanza_service/requirements.txt
+++ b/stanza_service/requirements.txt
@@ -1,7 +1,12 @@
 # Stanza service dependencies
 flask>=2.0.0
 gunicorn>=21.0.0
-stanza>=1.5.0
+# Pin stanza: 1.13+ expects the Danish DDT depparse model to have 41 dependency
+# relations, but our downloaded ddt_charlm.pt (Nov 2025) has 45 -> GraphParser
+# state_dict size mismatch -> every /tokenize with depparse 500s. 1.11.0 matches
+# the on-disk model (it's the version the API container tokenizes with today).
+# Re-pin only after re-downloading the models under the newer stanza.
+stanza==1.11.0
 psutil>=5.9.0
 
 # Stanza dependencies (PyTorch)


### PR DESCRIPTION
## Problem
The `/articles` feed (esp. Danish) is loading in ~30s, tripping the frontend "connection seems slow" screen.

**Root cause chain:**
1. The Stanza *service* image (`stanza_service/requirements.txt` had unpinned `stanza>=1.5.0`) was rebuilt to **stanza 1.13.0** on Jul 3. 1.13.0 builds the Danish DDT dependency parser expecting **41** deprel classes, but our on-disk `ddt_charlm.pt` (Nov 2025) has **45** → `GraphParser` state_dict size mismatch → **every `/tokenize` with depparse 500s** (first failure Jul 3 19:03; 4,765 failures on Jul 6).
2. The failed pipeline never gets cached, so the service **reloads all four models from disk on every request** before failing (~1.5s each).
3. The API container falls back to its **local stanza 1.11.0** (compatible with the model, so tokens are still correct) — but only after eating that ~1.5s failed round-trip per call.
4. The recommended feed tokenizes **10–15 simplified-article title+summary previews inline** (`elastic_recommender._add_simplified_overlays` → `ArticleTokenizationCache.ensure_populated`) against a near-empty cache (only ~10–15% of the 150–230 daily simplified DA articles are cached). 10–15 previews × ~1.5s × 2 (title+summary) ≈ 30s.

## Fix
Pin the service to **stanza 1.11.0** — the exact version the API container already tokenizes DA with successfully against the same model files. Restores clean model loading and kills the 500 storm + per-request 4-model reload.

Re-pin only after re-downloading the Stanza models under a newer version.

## Deploy
Requires rebuilding the `zeeguu/stanza:latest` image on the server (build context `src/api/stanza_service`) and restarting the `stanza` service.

## Follow-up
The structural issue — synchronous MWE tokenization of previews on the feed request path against a cold cache — is tracked separately (pre-warm cache at simplification time). This PR only removes the amplifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)