### PR TITLE
Warm tokenization cache for simplified articles at crawl time

### DIFF
--- a/zeeguu/core/content_retriever/article_downloader.py
+++ b/zeeguu/core/content_retriever/article_downloader.py
@@ -762,6 +762,11 @@ def download_feed_item(session, feed, feed_item, url, crawl_report, simplificati
             log(
                 f"   Created {len(simplified_articles)} simplified versions"
             )
+            # Pre-tokenize each simplified child's title/summary too. These are what
+            # the recommended feed renders as tappable preview cards; caching them
+            # here keeps that off the request path (mirrors the original above).
+            for simplified in simplified_articles:
+                _cache_article_tokenization(simplified, session)
             # Update topic simplification counts after successful simplification
             # Key is (language_id, topic_id) to track per language
             if topic_simplification_counts is not None:


### PR DESCRIPTION
## Why
Follow-up to the Jul 2026 slow-feed incident (stanza depparse 500s, fixed by #671). That removed the *amplifier*; this removes the *structural cause*.

The recommended feed renders each simplified article's title/summary as tappable preview cards, which needs MWE tokenization. We cached that at crawl time **only for the original article, not its simplified children** — so the feed tokenized 10–15 previews **inline on the request path** against a near-empty cache (~10–15% coverage vs 150–230 simplified articles created/day).

## What
`article_downloader`: after simplified children are created, warm each child's title/summary cache via the existing `_cache_article_tokenization` helper (already used for the original article a few lines above; it rolls back on failure and never breaks the crawl). 5-line change.

**No backfill** — the cache self-heals: 7-day cleanup + on-demand warm is only ~130ms now that #671 is in, so the existing backlog ages out as new crawls cache going forward.

## Follow-up (not in this PR)
Per `docs/future-work/preview-tokenization-cache-warming.md`: once the cache is reliably warm, make `_add_simplified_overlays` **read-only** with a graceful cache-miss (plain title instead of blocking to tokenize), so feed latency stops depending on tokenizer health entirely.

## Test notes
Syntax-checked; the hook reuses a helper already running in prod, so risk is low. Exercised on the next crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)