### PR TITLE
crontab: run tokenization-cache cleanup nightly (30-day retention)

### DIFF
--- a/zeeguu/operations/crontab
+++ b/zeeguu/operations/crontab
@@ -12,6 +12,10 @@ RUN=/home/zeeguu/src/api/zeeguu/operations/run_task.sh
 # cleanup old reports
 59 23 * * * find /home/zeeguu/data/crawl-reports/ -type f -mtime +7 -execdir rm -- '{}' \;
 
+# cleanup old tokenization cache (bounds the article_tokenization_cache table;
+# entries re-tokenize on demand when an old article is shown again)
+30 03 * * * $RUN cleanup_tokenization_cache tools/cleanup_tokenization_cache.py --days 30
+
 # weekly reports
 54 14 * * MON $RUN weekly_report tools/report_generator/generate_report.py
 


### PR DESCRIPTION
## Why
`tools/cleanup_tokenization_cache.py` (+ `ArticleTokenizationCache.delete_older_than`) existed but was **never wired into cron**. So `article_tokenization_cache` grew unbounded:

- **~266k rows / ~8 GB on disk** (~5 GB data: summary 2.2 GB, content 1.9 GB, title 0.85 GB)
- **96% older than 7 days**, oldest from **Nov 2025**

Every simplified article gets a permanent title+summary row, and #673/#674 now create them eagerly at crawl time — so the table needs an actual reaper.

## What
One crontab line: run the existing cleanup nightly at 03:30 with **30-day retention** (chosen so feed-visible articles older than a week don't churn-and-re-tokenize; 30d bounds the table to a few hundred MB). Old rows re-tokenize on demand (~130ms) if shown again.

## Not in this PR — one-time reclaim
`delete_older_than` is a single unbatched `DELETE`, fine for the steady-state nightly (~a day's worth) but heavy for the existing ~230k-row backlog. That initial cleanup should be run manually, in batches / during low traffic, followed by `OPTIMIZE TABLE` to actually shrink the 8 GB file. Runbook to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)