### PR TITLE
Broaden disturbing-content filter to catch death/burial themes

### DIFF
--- a/zeeguu/core/content_quality/disturbing_content_detection.py
+++ b/zeeguu/core/content_quality/disturbing_content_detection.py
@@ -6,7 +6,15 @@ Articles flagged here will still be saved but marked appropriately.
 """
 
 # Keywords by language for detecting disturbing content
-# Focus on words that appear in headlines/titles about violent/tragic current events
+# Focus on words that appear in headlines/titles about violent/tragic current events.
+#
+# The "Death imagery & morbid themes" category is intentionally broader than the
+# event-based categories: it catches articles whose SUBJECT is death/burial even
+# when nobody was killed (e.g. a "coffin therapy" lifestyle piece). Terms here are
+# chosen to be distinctive enough to survive naive substring matching, but by design
+# this category accepts a few false positives — the user-facing checkbox promises to
+# hide "death", not only tragedies. The LLM prompt (article_simplification.py) is the
+# real theme-level catch-all; this list is the fast, always-on pre-filter.
 DISTURBING_KEYWORDS = {
     "en": [
         # Violence & Crime
@@ -26,6 +34,9 @@ DISTURBING_KEYWORDS = {
         "deadly crash", "fatal crash", "plane crash", "train crash",
         "disaster kills", "earthquake kills", "tsunami kills",
         "building collapse", "fire kills",
+        # Death imagery & morbid themes (subject is death/burial, not necessarily an event)
+        "buried alive", "coffin", "coffins", "corpse", "corpses",
+        "morgue", "mortuary", "exhumed", "embalm",
     ],
     "fr": [
         # Violence & Crime
@@ -44,6 +55,9 @@ DISTURBING_KEYWORDS = {
         "accident mortel", "crash mortel",
         "catastrophe fait", "incendie meurtrier", "incendie mortel",
         "effondrement meurtrier",
+        # Death imagery & morbid themes (subject is death/burial, not necessarily an event)
+        "enterré vivant", "enterrée vivante", "cercueil", "cercueils",
+        "morgue", "exhumé", "inhumation",
     ],
     "es": [
         # Violence & Crime
@@ -62,6 +76,9 @@ DISTURBING_KEYWORDS = {
         "accidente mortal", "choque mortal",
         "desastre deja", "incendio mortal",
         "derrumbe mortal",
+        # Death imagery & morbid themes (subject is death/burial, not necessarily an event)
+        "enterrado vivo", "enterrada viva", "sepultado vivo",
+        "ataúd", "ataúdes", "morgue", "exhumado",
     ],
     "de": [
         # Violence & Crime
@@ -79,6 +96,9 @@ DISTURBING_KEYWORDS = {
         "tödlicher Unfall", "tödlicher Absturz",
         "Katastrophe fordert", "tödlicher Brand",
         "Einsturz",
+        # Death imagery & morbid themes (subject is death/burial, not necessarily an event)
+        "lebendig begraben", "Sarg", "Särge", "Leichnam",
+        "Leichenhalle", "exhumiert",
     ],
     "da": [
         # Violence & Crime
@@ -96,6 +116,9 @@ DISTURBING_KEYWORDS = {
         "dødsulykke", "dødsstyrtet",
         "katastrofe koster", "dødsbrand",
         "sammenstyrtning",
+        # Death imagery & morbid themes (subject is death/burial, not necessarily an event)
+        "begravet levende", "ligkiste", "lighus", "opgravet",
+        "balsameret",
     ],
     "nl": [
         # Violence & Crime
@@ -113,6 +136,9 @@ DISTURBING_KEYWORDS = {
         "dodelijk ongeluk", "dodelijke crash",
         "ramp kost", "dodelijke brand",
         "instorting",
+        # Death imagery & morbid themes (subject is death/burial, not necessarily an event)
+        "levend begraven", "doodskist", "lijkkist", "mortuarium",
+        "opgegraven", "gebalsemd",
     ],
     "it": [
         # Violence & Crime
@@ -130,6 +156,9 @@ DISTURBING_KEYWORDS = {
         "incidente mortale", "schianto mortale",
         "disastro causa", "incendio mortale",
         "crollo",
+        # Death imagery & morbid themes (subject is death/burial, not necessarily an event)
+        "sepolto vivo", "sepolta viva", "feretro",
+        "obitorio", "riesumato", "imbalsamato",
     ],
     "pt": [
         # Violence & Crime
@@ -148,6 +177,9 @@ DISTURBING_KEYWORDS = {
         "acidente fatal", "acidente mortal",
         "desastre deixa", "incêndio mortal",
         "desabamento",
+        # Death imagery & morbid themes (subject is death/burial, not necessarily an event)
+        "enterrado vivo", "enterrada viva", "sepultado vivo",
+        "caixão", "caixões", "necrotério", "exumado",
     ],
     "ro": [
         # Violence & Crime
@@ -165,6 +197,10 @@ DISTURBING_KEYWORDS = {
         "accident mortal", "accident fatal",
         "dezastru lasă", "incendiu mortal",
         "prăbușire", "colaps",
+        # Death imagery & morbid themes (subject is death/burial, not necessarily an event)
+        # "coșciug" also matches the plural "coșciuge"; "sicri" matches "sicriu"/"sicrie".
+        "îngropat de viu", "îngropați de vii", "sicri", "coșciug",
+        "înmormântare", "funeralii", "morgă", "exhumat",
     ],
 }
 

--- a/zeeguu/core/content_retriever/article_downloader.py
+++ b/zeeguu/core/content_retriever/article_downloader.py
@@ -119,6 +119,27 @@ def _cache_article_tokenization(article, session):
         # Don't fail the whole article download if tokenization fails
 
 
+def _save_classifications(session, article, classifications):
+    """
+    Persist a list of (classification_type, detection_method) tuples for an article.
+
+    Idempotent via ArticleClassification.find_or_create, so it is safe to call more
+    than once for the same article (e.g. the keyword pass and later the LLM pass).
+    """
+    if not classifications:
+        return
+
+    from zeeguu.core.model.article_classification import ArticleClassification
+
+    for classification_type, detection_method in classifications:
+        log(
+            f"Tagging article {article.id} as {classification_type} ({detection_method} detection)"
+        )
+        ArticleClassification.find_or_create(
+            session, article, classification_type, detection_method
+        )
+
+
 def should_filter_by_source_keywords(url, title):
     """
     Check if article should be filtered based on source-specific keywords.
@@ -722,7 +743,11 @@ def download_feed_item(session, feed, feed_item, url, crawl_report, simplificati
         new_article.set_as_broken(session, LowQualityTypes.ADVERTORIAL_PATTERN)
         return new_article
 
-    # Check for disturbing content (keyword-based detection)
+    # Check for disturbing content (keyword-based detection).
+    # Persist this flag NOW, decoupled from simplification: the LLM classification
+    # only runs if the article gets simplified, but simplification can be skipped
+    # (daily cap below, on-demand simplification, or an LLM error). The always-on
+    # keyword gate must set is_disturbing regardless, or the feed filter can't work.
     is_disturbing_keyword, disturbing_reason = is_disturbing_content_based_on_keywords(
         title=title, content=np_article.text, language=feed.language.code
     )
@@ -730,6 +755,7 @@ def download_feed_item(session, feed, feed_item, url, crawl_report, simplificati
         log(
             f"   ⚠ Disturbing content detected ({disturbing_reason})"
         )
+        _save_classifications(session, new_article, [("DISTURBING", "KEYWORD")])
 
     # Check topic simplification cap - skip simplification if all topics are "full" for this language today
     # topic_simplification_counts is keyed by (language_id, topic_id) tuple
@@ -783,31 +809,10 @@ def download_feed_item(session, feed, feed_item, url, crawl_report, simplificati
                 f"   No simplified versions created"
             )
 
-        # Collect all classifications (keyword + LLM) and save them once
-        all_classifications = []
-
-        # Add keyword-based classification
-        if is_disturbing_keyword:
-            all_classifications.append(("DISTURBING", "KEYWORD"))
-
-        # Add LLM-based classifications
-        all_classifications.extend(llm_classifications)
-
-        # Save all classifications at once
-        if all_classifications:
-            from zeeguu.core.model.article_classification import (
-                ArticleClassification,
-                ClassificationType,
-                DetectionMethod,
-            )
-
-            for classification_type, detection_method in all_classifications:
-                log(
-                    f"Tagging article {new_article.id} as {classification_type} ({detection_method} detection)"
-                )
-                ArticleClassification.find_or_create(
-                    session, new_article, classification_type, detection_method
-                )
+        # Save LLM-based classifications. The keyword-based DISTURBING flag was
+        # already persisted above, right after keyword detection, so it survives
+        # even when simplification is skipped or errors out.
+        _save_classifications(session, new_article, llm_classifications)
     except Exception as e:
         llm_duration = time() - llm_start_time
         error_msg = str(e).lower()

--- a/zeeguu/core/llm_services/prompts/article_simplification.py
+++ b/zeeguu/core/llm_services/prompts/article_simplification.py
@@ -88,7 +88,7 @@ MARKDOWN FORMATTING RULES:
 
 You must respond in the exact format shown below. Do NOT include any explanations, comments, or meta-text. All simplifications should be done in <<LANGUAGE_NAME>>.
 
-DISTURBING_CONTENT: [YES or NO - is the article's primary focus disturbing content (violence, death, disaster, tragedy)? This includes violent crimes, war, terrorism, accidents with casualties, tragic deaths, or graphic violence. Note: Historical or educational articles about difficult topics are acceptable - focus on current disturbing events.]
+DISTURBING_CONTENT: [YES or NO - would a reader who has asked to avoid disturbing material be upset by this article? Answer YES if EITHER (a) the article's focus is violence, death, or disaster AS AN EVENT - violent crimes, war, terrorism, accidents with casualties, tragic deaths, or graphic violence; OR (b) the article dwells on death/burial imagery and themes even when nobody was harmed - corpses, coffins, being buried (alive or dead), funerary, mortuary, or embalming practices, graphic bodily harm or medical gore. A lifestyle, wellness, or novelty piece whose SUBJECT is death or burial (e.g. "coffin therapy", being buried alive for relaxation) is YES. Note: brief incidental mentions in an otherwise neutral article do NOT count, and purely historical or educational treatment of a difficult topic is acceptable (NO).]
 
 ARTICLE_TYPE: [NEWS or GENERAL - NEWS = current events tied to a specific time (politics, breaking news, weather, sports results, someone visiting somewhere today, elections, daily events). GENERAL = evergreen content you could read months later (science explainers, cultural topics, how-to guides, historical articles, general knowledge, health/lifestyle advice).]
 


### PR DESCRIPTION
## Why

A Romanian **"coffin therapy"** article — a lifestyle/novelty piece about being buried alive in a sealed coffin for relaxation (tagged *Business*, from adevarul.ro) — passed the **"Avoid disturbing news (violence, death, disasters)"** filter and showed up for a user who had it enabled.

Root cause: the filter's notion of "death" is **death-as-a-news-event** (killings, war, disasters, fatal accidents), not **death-as-a-topic-or-image**. The article is morbid by *subject* but not a violent/tragic *event*, so it tripped neither detection gate:

- **Keyword pass** — the per-language lists are all hard-news death/violence vocabulary (`ucis`, `cadavru`, `atentat`, `prăbușire`…). None of the article's actual words (`sicriu`, `coșciug`, `îngropați`, `terapie`) were present.
- **LLM pass** — the prompt asked whether the *primary focus* is a *current disturbing event*, so a novelty wellness story reasonably came back `NO`.

Plus a structural gap: the keyword flag was only persisted *inside* the post-simplification block, so a capped/skipped/errored simplification silently dropped it.

## Changes

1. **Keyword detection** ([`disturbing_content_detection.py`](zeeguu/core/content_quality/disturbing_content_detection.py)) — new **"Death imagery & morbid themes"** category across all 9 languages (coffin / burial / corpse / morgue / exhume / buried-alive). Intentionally broader than the event-based categories and accepts some false positives — the checkbox promises to hide "death", not only tragedies. Romanian now matches `sicri(u)` / `coșciug`, which catches the reported article **by title alone**.

2. **LLM prompt** ([`article_simplification.py`](zeeguu/core/llm_services/prompts/article_simplification.py)) — the `DISTURBING_CONTENT` question now flags death/burial **imagery and themes** (corpses, coffins, being buried, funerary/mortuary practices, medical gore) in addition to tragic events, with an explicit example that a novelty/wellness piece whose subject *is* death/burial is `YES`. Incidental mentions and purely historical/educational treatment remain `NO`.

3. **Decouple classification from simplification** ([`article_downloader.py`](zeeguu/core/content_retriever/article_downloader.py)) — persist the keyword-based `DISTURBING` flag **immediately after detection**, before the daily simplification-cap early-return, so the flag is set even when simplification is skipped/capped/errored. Extracted a `_save_classifications` helper; `find_or_create` keeps the later LLM save idempotent.

## Verification

```
RO article:        (True, 'Disturbing content keywords: sicri, coșciug')
EN coffin:         (True, 'Disturbing content keywords: buried alive, coffin')
Neutral RO control:(False, '')
Neutral EN control:(False, '')
```

## Notes

- Affects **newly crawled** articles only — already-indexed articles won't be reflagged without a backfill. Happy to add a one-off tool to re-run keyword detection over recent articles if we want the fix applied retroactively.
- No existing tests cover this detection; can add a unit test for the keyword lists in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)