### PR TITLE
Stop /teacher_texts tokenizing every owned text on each load

### DIFF
--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -754,7 +754,14 @@ class Article(db.Model):
     def article_info_for_teacher(self):
         from zeeguu.core.model import CohortArticleMap
 
-        info = self.article_info(with_content=True)
+        # NB: with_content=False on purpose. This is the teacher list/metadata
+        # view; it needs CEFR + metrics, not per-token reader data. Passing
+        # with_content=True made /teacher_texts synchronously Stanza/MWE-tokenize
+        # the full body of every owned text on each load (see get_tokenized_content),
+        # which could time the request out. The one caller that does need tokens
+        # (UserArticle reader path) re-fetches content itself via
+        # article_info(with_content=True) and merges it.
+        info = self.article_info(with_content=False)
         info["cohorts"] = CohortArticleMap.get_cohorts_for_article(self)
 
         # Include CEFR assessment details for teacher view


### PR DESCRIPTION
## Problem

The **My Texts** teacher page was slow and often failed to load, surfacing in the browser console as `net::ERR_FAILED` + "No 'Access-Control-Allow-Origin' header" on `GET /teacher_texts`. The API logs showed a flood of `MWE enrichment` / `[CACHE-MISS] Article N - Tokenizing content with MWE detection`.

## Root cause

`GET /teacher_texts` → `teacher_texts()` loops over every text the teacher owns → `article_info_for_teacher()` → `article_info(with_content=True)` → `get_tokenized_content()`, which runs **full Stanza/MWE tokenization of the entire article body**, synchronously, for every un-cached text, on **every** page load.

For a teacher with many texts this is a lot of synchronous NLP work on the request thread. When it runs long enough the worker/nginx times out and returns a 502/504 — and error responses skip Flask's CORS `after_request` handler, so the browser gets no `Access-Control-Allow-Origin` header and reports it as a (phantom) CORS failure + `net::ERR_FAILED`.

## Fix

The list view only needs title / summary / CEFR / metrics — not per-token reader data. So `article_info_for_teacher()` now passes `with_content=False`.

## Why it's safe (both callers checked)

- **`/teacher_texts` list** → feeds only `TeacherTextPreview`, which reads metadata; never `content`/`tokenized_*`.
- **Teacher reader path** (`UserArticle`) → already re-fetches `article_info(with_content=True)` itself and merges the `content`/`tokenized` keys when content is requested, so it doesn't rely on the teacher-info dict carrying them.
- **Web edit view** (`EditText.js`) reads `content`/`htmlContent`, but from a separate `getArticleInfo(articleID)` call, not the list payload.

Net effect: tokenization now happens (and caches) only when a text is actually opened, not on every list load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)