### PR TITLE
On-platform article sharing: backend (shared_article + endpoints)

### DIFF
--- a/tools/migrations/26-07-31--add_shared_article.sql
+++ b/tools/migrations/26-07-31--add_shared_article.sql
@@ -1,0 +1,19 @@
+-- On-platform "share an article with a friend".
+--
+-- One row = one friend sending one article to another, with an optional note.
+-- article_id is the ORIGINAL/parent article id (never the sharer's adapted or
+-- translated copy) so the recipient's reader can adapt it to their own language
+-- and level on open. read_at / dismissed_at track the recipient's inbox state.
+CREATE TABLE shared_article (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    from_user_id INT NOT NULL,
+    to_user_id INT NOT NULL,
+    article_id INT NOT NULL,
+    note VARCHAR(500),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    read_at DATETIME,
+    dismissed_at DATETIME,
+    FOREIGN KEY (from_user_id) REFERENCES user(id),
+    FOREIGN KEY (to_user_id) REFERENCES user(id),
+    FOREIGN KEY (article_id) REFERENCES article(id)
+);

--- a/zeeguu/api/endpoints/friends.py
+++ b/zeeguu/api/endpoints/friends.py
@@ -8,8 +8,11 @@ from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
 from zeeguu.core.friends.friend_streak import compute_current_streak
 from zeeguu.core.model import User
 from zeeguu.core.model import UserLanguage
+from zeeguu.core.model.db import db
+from zeeguu.core.model.article import Article
 from zeeguu.core.model.friend_request import FriendRequest
 from zeeguu.core.model.friendship import Friendship
+from zeeguu.core.model.shared_article import SharedArticle
 from zeeguu.core.model.user_avatar import UserAvatar
 from zeeguu.logging import log
 from . import api
@@ -392,3 +395,86 @@ def _validate_friend_request_participants(sender_id: int, receiver_id: int) -> t
         return 422, "cannot send friend request to yourself"
 
     return 200, "ok"
+
+
+# ---------------------------------------------------------------------------
+@api.route("/share_article_with_friend", methods=["POST"])
+# ---------------------------------------------------------------------------
+@cross_domain
+@requires_session
+def share_article_with_friend():
+    """
+    Share an article with an accepted friend.
+
+    Body (JSON): { friend_username, article_id, note? }
+
+    We store the ORIGINAL/parent article id (never the sharer's adapted or
+    translated copy) so the recipient's reader adapts it to their own language
+    and level on open.
+    """
+    from_user_id = flask.g.user_id
+    friend_username = request.json.get("friend_username")
+    article_id = request.json.get("article_id")
+    note = request.json.get("note")
+
+    if not friend_username or not article_id:
+        return make_error(400, "friend_username and article_id are required")
+
+    friend = User.find_by_username(friend_username)
+    if not friend:
+        return make_error(404, "user not found")
+
+    to_user_id = friend.id
+    if to_user_id == from_user_id:
+        return make_error(422, "cannot share with yourself")
+
+    # are_friends returns True for self, so the self-check above must come first.
+    if not Friendship.are_friends(from_user_id, to_user_id):
+        return make_error(403, "you can only share with your friends")
+
+    article = Article.find_by_id(article_id)
+    if not article:
+        return make_error(404, "article not found")
+
+    original_id = SharedArticle.resolve_original_article_id(article)
+    shared = SharedArticle.create(db.session, from_user_id, to_user_id, original_id, note)
+    return json_result({"shared_article_id": shared.id})
+
+
+# ---------------------------------------------------------------------------
+@api.route("/articles_shared_with_me", methods=["GET"])
+# ---------------------------------------------------------------------------
+@cross_domain
+@requires_session
+def articles_shared_with_me():
+    """Inbox: non-dismissed articles shared with the current user, newest first."""
+    shares = SharedArticle.inbox_for(flask.g.user_id)
+    return json_result([s.to_dict() for s in shares])
+
+
+# ---------------------------------------------------------------------------
+@api.route("/mark_shared_article_read", methods=["POST"])
+# ---------------------------------------------------------------------------
+@cross_domain
+@requires_session
+def mark_shared_article_read():
+    """Mark a received share as read. Body (JSON): { shared_article_id }."""
+    shared = SharedArticle.find_by_id(request.json.get("shared_article_id"))
+    if not shared or shared.to_user_id != flask.g.user_id:
+        return make_error(404, "shared article not found")
+    shared.mark_read(db.session)
+    return json_result("OK")
+
+
+# ---------------------------------------------------------------------------
+@api.route("/dismiss_shared_article", methods=["POST"])
+# ---------------------------------------------------------------------------
+@cross_domain
+@requires_session
+def dismiss_shared_article():
+    """Remove a share from the recipient's inbox. Body (JSON): { shared_article_id }."""
+    shared = SharedArticle.find_by_id(request.json.get("shared_article_id"))
+    if not shared or shared.to_user_id != flask.g.user_id:
+        return make_error(404, "shared article not found")
+    shared.dismiss(db.session)
+    return json_result("OK")

--- a/zeeguu/core/model/__init__.py
+++ b/zeeguu/core/model/__init__.py
@@ -131,4 +131,5 @@ from .user_avatar import UserAvatar
 # friends
 from .friend_request import FriendRequest
 from .friendship import Friendship
+from .shared_article import SharedArticle
 

--- a/zeeguu/core/model/shared_article.py
+++ b/zeeguu/core/model/shared_article.py
@@ -1,0 +1,117 @@
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, func
+from sqlalchemy.orm import relationship
+
+from zeeguu.core.model.db import db
+from zeeguu.core.model.user import User
+from zeeguu.core.model.article import Article
+
+
+class SharedArticle(db.Model):
+    """One friend sharing one article with another, on-platform.
+
+    ``article_id`` is always the ORIGINAL/parent article id, never the sharer's
+    adapted or translated copy, so the recipient's reader adapts it to their own
+    language and level on open. ``read_at`` / ``dismissed_at`` track the
+    recipient's inbox state.
+    """
+
+    __tablename__ = "shared_article"
+    __table_args__ = {"mysql_collate": "utf8_bin"}
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    from_user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
+    to_user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
+    article_id = Column(Integer, ForeignKey("article.id"), nullable=False)
+    note = Column(String(500), nullable=True)
+    created_at = Column(DateTime, default=func.now())
+    read_at = Column(DateTime, nullable=True)
+    dismissed_at = Column(DateTime, nullable=True)
+
+    from_user = relationship(User, foreign_keys=[from_user_id])
+    to_user = relationship(User, foreign_keys=[to_user_id])
+    article = relationship(Article, foreign_keys=[article_id])
+
+    def __init__(self, from_user_id: int, to_user_id: int, article_id: int, note: str = None):
+        self.from_user_id = from_user_id
+        self.to_user_id = to_user_id
+        self.article_id = article_id
+        self.note = note
+
+    @staticmethod
+    def resolve_original_article_id(article) -> int:
+        """The id of the original/parent article to store for a share.
+
+        Adapted/simplified copies point at their parent via ``parent_article_id``.
+        Translated copies (today) don't set a parent — they encode the origin in
+        a ``URL#translated-from-...`` fragment — so fall back to the pre-fragment
+        original. Anything else is already an original.
+        """
+        if article.parent_article_id:
+            return article.parent_article_id
+
+        url = article.url.as_string()
+        fragment_marker = "#translated-from-"
+        if fragment_marker in url:
+            original_url = url.split(fragment_marker)[0]
+            try:
+                original = Article.find(original_url)
+                if original:
+                    return original.id
+            except Exception:
+                pass  # original not in the DB — fall through to using this article
+
+        return article.id
+
+    @classmethod
+    def create(cls, session, from_user_id: int, to_user_id: int, article_id: int, note: str = None):
+        shared = cls(from_user_id, to_user_id, article_id, note)
+        session.add(shared)
+        session.commit()
+        return shared
+
+    @classmethod
+    def find_by_id(cls, shared_id):
+        return cls.query.filter(cls.id == shared_id).first()
+
+    @classmethod
+    def inbox_for(cls, user_id: int):
+        """Non-dismissed shares received by the user, newest first."""
+        return (
+            cls.query.filter(cls.to_user_id == user_id)
+            .filter(cls.dismissed_at.is_(None))
+            .order_by(cls.created_at.desc())
+            .all()
+        )
+
+    @classmethod
+    def unread_count_for(cls, user_id: int) -> int:
+        return (
+            cls.query.filter(cls.to_user_id == user_id)
+            .filter(cls.read_at.is_(None))
+            .filter(cls.dismissed_at.is_(None))
+            .count()
+        )
+
+    def mark_read(self, session):
+        if self.read_at is None:
+            self.read_at = datetime.now()
+            session.add(self)
+            session.commit()
+
+    def dismiss(self, session):
+        self.dismissed_at = datetime.now()
+        session.add(self)
+        session.commit()
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "from_user_id": self.from_user_id,
+            "from_user_name": self.from_user.name,
+            "note": self.note,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "read": self.read_at is not None,
+            "article": self.article.article_info(with_content=False),
+        }


### PR DESCRIPTION
Backend for sharing an article with an accepted friend, on-platform. Pairs with the web PR (zeeguu/web).

Design: `docs/future-work/share-article-to-friend.md`.

## What

- **Migration** `26-07-31--add_shared_article.sql` — `shared_article` (from/to user, original article id, note, created_at, read_at, dismissed_at).
- **`SharedArticle` model** — original-article resolution (store the parent, not the sharer's adapted/translated copy: `parent_article_id`, else the `#translated-from-` URL fragment's origin), `inbox_for` / `unread_count_for`, `mark_read` / `dismiss`, `to_dict` with an article preview.
- **Endpoints** (`friends.py`): `POST /share_article_with_friend` (gated on an accepted friendship, self-share blocked), `GET /articles_shared_with_me`, `POST /mark_shared_article_read`, `POST /dismiss_shared_article`.

Delivery ("arrives in the recipient's language") needs no new code — the recipient's reader adapts the original via the existing `/translate_and_adapt_article`.

## Note

**Migration not yet run.** Apply `tools/migrations/26-07-31--add_shared_article.sql` before testing.

Verified: model registers with SQLAlchemy metadata, endpoints compile. Not yet exercised against a live DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)