### PR TITLE
SharedArticle.to_dict: include sharer username (link inbox → profile)

### DIFF
--- a/zeeguu/core/model/shared_article.py
+++ b/zeeguu/core/model/shared_article.py
@@ -110,6 +110,7 @@ class SharedArticle(db.Model):
             "id": self.id,
             "from_user_id": self.from_user_id,
             "from_user_name": self.from_user.name,
+            "from_user_username": self.from_user.username,
             "note": self.note,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "read": self.read_at is not None,


### PR DESCRIPTION
Tiny follow-up to #682. Adds `from_user_username` to the shared-article payload so the web "Shared with you" inbox can link *"Shared by \<name\>"* to the sharer's profile (`/profile/:username`).

Pairs with the corresponding web change on `feature/share-article-with-friend` (#1195). Backward-compatible: the web side guards on the field's presence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)