### PR TITLE
Reader: expose simplification target CEFR level

### DIFF
--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -704,6 +704,19 @@ class Article(db.Model):
         if self.simplification_ai_generator_id:
             result_dict["is_simplified"] = True
 
+            # Expose the *target* CEFR level the simplification was generated at.
+            # Deliberately NOT metrics.cefr_level: that is effective_cefr_level, a
+            # synthesis of target + ML re-measurement that can come back compound
+            # (e.g. "B1/B2"). The target is the reliable, intended level, so that
+            # is what we surface to the reader (see feedback_cefr_data_unreliable).
+            target_cefr_level = (
+                self.cefr_assessment.simplification_target_level
+                if self.cefr_assessment
+                else None
+            ) or self.cefr_level
+            if target_cefr_level:
+                result_dict["target_cefr_level"] = target_cefr_level
+
         # Add simplified article metadata if this is a simplified version
         if self.parent_article_id:
             result_dict["parent_article_id"] = self.parent_article_id


### PR DESCRIPTION
## What

`article_info()` now includes `target_cefr_level` for AI-simplified articles — the reliable `simplification_target_level` from the assessment table (falling back to the legacy `article.cefr_level` column set at generation time).

## Why

The reader already gets `metrics.cefr_level`, but that's `effective_cefr_level` — a synthesis of the simplification target and an ML re-measurement, which can come back **compound** (e.g. `"B1/B2"`) when the two disagree. That's exactly the classifier-flavoured value we suppress from users (see `feedback_cefr_data_unreliable`). The *target* level is the intended, trustworthy number, so we expose that instead.

Only added for simplified articles; absent for everything else.

## Web counterpart

zeeguu/web `wt/simplified-level` renders it as `Simplified to B1`. **Deploy this api change first** — until it's live the badge just shows plain `Simplified`.

## Test plan

- [ ] Open a simplified article in the reader → badge shows the target level
- [ ] Open a non-simplified article → no `target_cefr_level`, no regression
- [ ] Open an older simplified article lacking an assessment row → falls back to legacy `cefr_level`

🤖 Generated with [Claude Code](https://claude.com/claude-code)