### PR TITLE
Reader: show real origin for simplified shared/uploaded articles

### DIFF
--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -230,6 +230,7 @@ class Article(db.Model):
     # Set when this article was derived from a user's ArticleUpload
     # (extension body-scrape or iOS share). Nullable for normal feed articles.
     source_upload_id = Column(Integer, ForeignKey("article_upload.id"))
+    source_upload = relationship("ArticleUpload", foreign_keys=[source_upload_id])
 
     topics = relationship(
         "ArticleTopicMap",
@@ -713,6 +714,13 @@ class Article(db.Model):
             # Include parent URL for reference
             if self.parent_article and self.parent_article.url:
                 result_dict["parent_url"] = self.parent_article.url.as_string()
+        elif self.source_upload_id and self.source_upload and self.source_upload.url:
+            # Simplified from a shared/uploaded article (extension or phone
+            # share) — there is no crawled parent Article, but the upload row
+            # still holds the true origin URL (e.g. politiken.dk). Surface it as
+            # parent_url so the reader's "Original:" link points at the real
+            # source instead of the article's own zeeguu.org placeholder URL.
+            result_dict["parent_url"] = self.source_upload.url.as_string()
 
         if self.authors:
             result_dict["authors"] = self.authors


### PR DESCRIPTION
Simplifications made from an article **shared via the extension or phone** (`source_upload`, no crawled parent) fell back to the article's own `zeeguu.org` placeholder URL, so the reader showed a useless `Original: zeeguu.org` self-link.

The real origin URL is stored on the `article_upload` row (its `url_id` is `NOT NULL`), so this exposes it as `parent_url` in `article_info()` when there's no parent `Article`. No frontend change — the existing `parent_url || url` + `Original:` logic just works.

Fixes the ~160 existing upload-based simplifications, e.g. article 4837215 → `Original: politiken.dk`.

Follow-up (separate): make `create_simplified_version_from_upload` promote the upload to a real parent Article at simplify time, so *new* shares get a uniform parent (unlocking level-switching / topics too). This PR is the read-time fix that also covers all legacy rows without a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)