### PR TITLE
Friend-share: resolve uploaded-article shares to the promoted original

### DIFF
--- a/zeeguu/api/endpoints/friends.py
+++ b/zeeguu/api/endpoints/friends.py
@@ -436,7 +436,7 @@ def share_article_with_friend():
     if not article:
         return make_error(404, "article not found")
 
-    original_id = SharedArticle.resolve_original_article_id(article)
+    original_id = SharedArticle.resolve_shareable_original_id(db.session, article)
     shared = SharedArticle.create(db.session, from_user_id, to_user_id, original_id, note)
 
     # Notify the recipient by email — best-effort, off the request thread.

--- a/zeeguu/core/model/shared_article.py
+++ b/zeeguu/core/model/shared_article.py
@@ -65,6 +65,47 @@ class SharedArticle(db.Model):
         return article.id
 
     @classmethod
+    def resolve_shareable_original_id(cls, session, article) -> int:
+        """Resolve the original article id to store for a share, promoting an
+        upload-based original into a real Article when needed.
+
+        `resolve_original_article_id` handles crawled/translated copies. But a
+        simplification made from a user upload (extension / phone share) has no
+        `parent_article_id` and a placeholder URL, so that resolver would fall
+        through and share the *simplified* copy — leaving the recipient unable to
+        re-adapt from the original. Such articles carry a `source_upload` whose
+        row holds the true origin (URL + content); promote it to a real Article
+        (deduped by URL) so the recipient opens the original and adapts on open.
+
+        Falls back to the plain resolver if the upload can't be promoted (e.g. a
+        paywalled original that won't parse) — better to share the copy than to
+        fail the share.
+        """
+        if (
+            not article.parent_article_id
+            and article.source_upload_id
+            and article.source_upload
+        ):
+            upload = article.source_upload
+            try:
+                original = Article.find_or_create(
+                    session,
+                    upload.url.as_string(),
+                    html_content=upload.raw_html,
+                    text_content=upload.text_content,
+                    title=upload.title,
+                    author=upload.author,
+                    image_url=upload.image_url,
+                    source_upload_id=upload.id,
+                )
+                if original:
+                    return original.id
+            except Exception:
+                pass  # original won't promote (paywall/parse) — fall through
+
+        return cls.resolve_original_article_id(article)
+
+    @classmethod
     def create(cls, session, from_user_id: int, to_user_id: int, article_id: int, note: str = None):
         shared = cls(from_user_id, to_user_id, article_id, note)
         session.add(shared)


### PR DESCRIPTION
## Problem

Sharing a simplification that was made from an **extension/phone upload** stored the wrong `article_id`. [`resolve_original_article_id`](../zeeguu/core/model/shared_article.py) resolves via `parent_article_id` or a `#translated-from-` URL fragment; an upload-based simplification has **neither** (no parent, and a `zeeguu.org/simplified/pending/<uuid>` placeholder URL), so it fell through to `return article.id` — sharing the **A1 copy itself**. The recipient then opens the sharer's adapted copy and can't re-adapt from the original for their own language/level.

## Fix

New `SharedArticle.resolve_shareable_original_id(session, article)`: when there's no parent but the article has a `source_upload`, **promote that upload to a real `Article`** (`Article.find_or_create`, deduped by URL, using the already-captured `text_content` — no network fetch) and share *its* id. The recipient opens the true original (e.g. politiken.dk) and adapts on open, exactly like a crawled share.

Consistent with the shipped "share the original, recipient re-adapts on open" model — no schema change. Chose this (approach A) over a per-user-copy redesign (B) because copies don't actually solve the copyright question either; the real lever is per-article **access control**, deferred as future work.

Safety: if the original won't promote (paywall/parse failure), it falls back to the plain resolver — a share never fails.

## Test plan

- [x] `pytest .../test_friends.py` (24 passed)
- [ ] On device: share an extension/phone-uploaded+simplified article with a friend → their inbox opens the **original** (real publisher), adapts to their level/language — not the sharer's A1 copy.

See [`docs/future-work/track-original-on-send-and-simplify.md`](../docs/future-work/track-original-on-send-and-simplify.md) and [`share-article-to-friend.md`](../docs/future-work/share-article-to-friend.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)