### PR TITLE
Friend-share: full-body multiplexer (resolver + recipient derivative)

### DIFF
--- a/tools/migrations/26-08-01--add_article_upload_article_id.sql
+++ b/tools/migrations/26-08-01--add_article_upload_article_id.sql
@@ -1,0 +1,27 @@
+-- Flip the upload<->article link onto the article_upload table.
+--
+-- Reality: one real-world article (one publisher URL) can be uploaded by MANY
+-- users (e.g. a subscriber captures the full body; a non-subscriber captures
+-- only the teaser). A single `article.source_upload_id` (added in #688) can
+-- only reference ONE upload, so it models the relationship backwards. The
+-- correct shape is many uploads : one article, i.e. the FK belongs here, on
+-- the upload, pointing at the canonical article that lives at the same URL.
+--
+-- See docs/future-work/article-body-provenance-and-sharing.md. This is
+-- ADDITIVE: `article.source_upload_id` is left in place during the transition
+-- (a later migration removes it once all readers move over).
+ALTER TABLE article_upload
+    ADD COLUMN article_id INT NULL
+        COMMENT 'The canonical article at this upload''s URL (many uploads : one article). NULL until an article exists at the URL.',
+    ADD CONSTRAINT fk_article_upload_article
+        FOREIGN KEY (article_id) REFERENCES article(id);
+
+-- Backfill: link each upload to the article that already sits at the same URL
+-- (article.url_id is UNIQUE, so this matches at most one). Uploads whose URL has
+-- never been crawled stay NULL. NOTE: this is NOT the reverse of
+-- article.source_upload_id — that column lives on the simplified CHILD (which
+-- has a synthetic zeeguu.org URL), not on the canonical article.
+UPDATE article_upload au
+    JOIN article a ON a.url_id = au.url_id
+SET au.article_id = a.id
+WHERE au.article_id IS NULL;

--- a/tools/migrations/26-08-01-b--add_shared_article_delivery.sql
+++ b/tools/migrations/26-08-01-b--add_shared_article_delivery.sql
@@ -1,0 +1,17 @@
+-- The recipient's personalized derivative for a share ("the multiplexer out").
+--
+-- article_id stays the canonical article (the handle + "See original"). These
+-- add the copy the recipient actually reads: generated from the SHARER's upload
+-- body, in the recipient's delivery language at their level.
+--   delivery_language_id : the language the recipient receives it in (source
+--                          language if they learn it, else their primary).
+--   delivery_article_id  : the generated derivative; NULL until it's ready.
+--
+-- See docs/future-work/article-body-provenance-and-sharing.md.
+ALTER TABLE shared_article
+    ADD COLUMN delivery_language_id INT NULL,
+    ADD COLUMN delivery_article_id INT NULL,
+    ADD CONSTRAINT fk_shared_article_delivery_language
+        FOREIGN KEY (delivery_language_id) REFERENCES language(id),
+    ADD CONSTRAINT fk_shared_article_delivery_article
+        FOREIGN KEY (delivery_article_id) REFERENCES article(id);

--- a/zeeguu/api/endpoints/friends.py
+++ b/zeeguu/api/endpoints/friends.py
@@ -436,16 +436,66 @@ def share_article_with_friend():
     if not article:
         return make_error(404, "article not found")
 
-    original_id = SharedArticle.resolve_original_article_id(article)
-    shared = SharedArticle.create(db.session, from_user_id, to_user_id, original_id, note)
-
-    # Notify the recipient by email — best-effort, off the request thread.
+    # Everything heavy — resolving the canonical article, generating the
+    # recipient's personalized copy, creating the share row, emailing — runs in
+    # the background so the sharer's Send returns immediately. The row is created
+    # LAST, already carrying the derivative, so a share only ever appears in an
+    # inbox once it's ready in the recipient's language (no not-ready window).
+    # Trade-off: the client's "Shared with X" is optimistic — the row lands a few
+    # seconds later.
     from zeeguu.api.utils.background import run_in_background
-    from zeeguu.core.emailer.shared_article import send_shared_article_notification
 
-    run_in_background(send_shared_article_notification, to_user_id, from_user_id, shared.id)
+    run_in_background(_deliver_share, from_user_id, to_user_id, article_id, note)
 
-    return json_result({"shared_article_id": shared.id})
+    return json_result({"status": "sharing"})
+
+
+def _deliver_share(from_user_id: int, to_user_id: int, article_id: int, note):
+    """Background: resolve the canonical article, generate the recipient's
+    personalized copy, create the (complete) share row, and email. Re-queries
+    everything by id (own app context / session)."""
+    article = Article.find_by_id(article_id)
+    recipient = User.find_by_id(to_user_id)
+    if not article or not recipient:
+        return
+
+    original_id = SharedArticle.resolve_shareable_original_id(db.session, article)
+    delivery_language_id, delivery_article_id = _recipient_derivative_for(article, recipient)
+
+    shared = SharedArticle.create(
+        db.session, from_user_id, to_user_id, original_id, note,
+        delivery_language_id=delivery_language_id,
+        delivery_article_id=delivery_article_id,
+    )
+
+    try:
+        from zeeguu.core.emailer.shared_article import send_shared_article_notification
+
+        send_shared_article_notification(to_user_id, from_user_id, shared.id)
+    except Exception as e:
+        log(f"share {shared.id}: email notification failed: {e}")
+
+
+def _recipient_derivative_for(article, recipient):
+    """(delivery_language_id, delivery_article_id) for a share of `article` to
+    `recipient`. Returns (None, None) for a plain crawl share (no upload body),
+    and (language_id, None) if generation fails — the recipient then opens the
+    canonical article and adapts it in the reader, so a share never fails."""
+    from zeeguu.core.llm_services.simplification_and_classification import (
+        create_recipient_derivative,
+    )
+
+    upload = article.source_upload
+    if upload is None:
+        return None, None
+
+    delivery_language, level = SharedArticle.compute_delivery_language(recipient, upload)
+    derivative = create_recipient_derivative(db.session, upload, delivery_language.code, level)
+    if derivative is None:
+        log(f"share to user_id={recipient.id}: derivative generation failed; "
+            f"recipient will open the canonical article")
+        return delivery_language.id, None
+    return delivery_language.id, derivative.id
 
 
 # ---------------------------------------------------------------------------

--- a/zeeguu/api/endpoints/friends.py
+++ b/zeeguu/api/endpoints/friends.py
@@ -489,8 +489,21 @@ def _recipient_derivative_for(article, recipient):
     if upload is None:
         return None, None
 
-    delivery_language, level = SharedArticle.compute_delivery_language(recipient, upload)
-    derivative = create_recipient_derivative(db.session, upload, delivery_language.code, level)
+    # Never let a generation failure drop the share: _deliver_share creates the
+    # row AFTER this, so any exception raised here would skip row creation
+    # entirely (recipient with no learned_language, fragment/LLM/DB error, …).
+    # Degrade to "no derivative" — the recipient opens the canonical article and
+    # adapts it in the reader — and roll back so the dirty session doesn't taint
+    # the subsequent row commit.
+    try:
+        delivery_language, level = SharedArticle.compute_delivery_language(recipient, upload)
+        derivative = create_recipient_derivative(db.session, upload, delivery_language.code, level)
+    except Exception as e:
+        db.session.rollback()
+        log(f"share to user_id={recipient.id}: derivative generation errored "
+            f"({e}); recipient will open the canonical article")
+        return None, None
+
     if derivative is None:
         log(f"share to user_id={recipient.id}: derivative generation failed; "
             f"recipient will open the canonical article")

--- a/zeeguu/core/llm_services/simplification_and_classification.py
+++ b/zeeguu/core/llm_services/simplification_and_classification.py
@@ -859,6 +859,112 @@ def create_user_specific_simplified_version(session, article, target_level):
         return None
 
 
+def create_recipient_derivative(session, upload, target_language_code, target_level):
+    """A recipient's personalized full-body copy, generated from a SHARER's upload.
+
+    The multiplexer's "out" side: the sharer captured the full body (`upload`),
+    and each recipient reads it in *their* language at *their* level.
+
+      - **same language** (target == upload.language): simplify to ``target_level``.
+      - **cross language**: translate + adapt to ``target_language_code``.
+
+    Cached per (upload, language, level) — the same-language variant via
+    (source_upload_id, cefr_level, language), the cross-language variant via the
+    ``#translated-from-…`` URL key — so a second recipient at the same
+    language+level reuses the first one's article. Returns the Article, or
+    ``None`` if generation failed (too long / LLM error).
+    """
+    from zeeguu.core.model.article import Article
+    from zeeguu.core.model import Language
+    from zeeguu.core.model.url import Url
+    from zeeguu.core.model.source import Source
+    from zeeguu.core.model.source_type import SourceType
+    from zeeguu.core.llm_services.simplification_service import SimplificationService
+    from datetime import datetime
+    from zeeguu.logging import log
+
+    if not upload.language:
+        log(f"Upload {upload.id} has no language; cannot build recipient derivative")
+        return None
+    source_language_code = upload.language.code
+
+    # Same language → simplify to level (reuse the upload-simplify path + cache).
+    if target_language_code == source_language_code:
+        existing = (
+            Article.query.filter_by(
+                source_upload_id=upload.id,
+                cefr_level=target_level,
+                language_id=upload.language_id,
+            )
+            .filter(Article.parent_article_id.is_(None))
+            .first()
+        )
+        if existing:
+            return existing
+        return create_simplified_version_from_upload(session, upload, target_level)
+
+    # Cross language → translate + adapt, cached under the #translated-from key
+    # (mirrors POST /article_upload/<id>/translate_and_adapt).
+    translated_url_key = (
+        f"{upload.url.as_string()}"
+        f"#translated-from-{source_language_code}-to-{target_language_code}-{target_level}"
+    )
+    existing = Article.find(translated_url_key)
+    if existing:
+        return existing
+
+    content = upload.text_content or upload.raw_html or ""
+    title = upload.title or ""
+    if not content.strip():
+        return None
+
+    try:
+        result = SimplificationService().translate_and_adapt(
+            title=title,
+            content=content,
+            source_language=source_language_code,
+            target_language=target_language_code,
+            target_level=target_level,
+        )
+    except Exception as e:
+        log(f"translate_and_adapt failed for upload {upload.id}: {e}")
+        return None
+    if not result:
+        log(f"translate_and_adapt returned nothing for upload {upload.id}")
+        return None
+
+    translated_url = Url.find_or_create(session, translated_url_key)
+    target_lang_obj = Language.find(target_language_code)
+    source_type = SourceType.find_by_type(SourceType.ARTICLE)
+    source_obj = Source.find_or_create(
+        session, result["content"], source_type, target_lang_obj, 0
+    )
+    clean_summary = result.get("summary") or (result["content"][:200] + "...")
+
+    translated = Article(
+        translated_url,
+        result["title"],
+        None,
+        source_obj,
+        clean_summary,
+        datetime.now(),
+        None,
+        target_lang_obj,
+        result["content"],
+        None,
+    )
+    translated.cefr_level = target_level
+    translated.source_upload_id = upload.id
+    if upload.image_url:
+        translated.img_url = Url.find_or_create(session, upload.image_url)
+
+    session.add(translated)
+    session.commit()
+    translated.create_article_fragments(session)
+    session.commit()
+    return translated
+
+
 def create_simplified_version_from_upload(session, upload, target_level):
     """
     Simplify an ArticleUpload directly at target_level. No parent Article

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -738,6 +738,22 @@ class Article(db.Model):
             # source instead of the article's own zeeguu.org placeholder URL.
             result_dict["parent_url"] = self.source_upload.url.as_string()
 
+        # Cross-language derivative → is_translated, a flag DISTINCT from
+        # is_simplified (which is same-language level adaptation). Derived, not
+        # stored: this article's language differs from its origin's — the upload
+        # it was translated from, or its parent. (translate_and_adapt always also
+        # adapts to a level, so the reader renders is_translated as "Translated &
+        # simplified".) The crawl→translate path sets neither link and encodes the
+        # origin in a #translated-from URL fragment instead, so it's not derivable
+        # here yet — see unify-translated-copies-onto-parent.md.
+        origin_language_id = None
+        if self.source_upload_id and self.source_upload:
+            origin_language_id = self.source_upload.language_id
+        elif self.parent_article_id and self.parent_article:
+            origin_language_id = self.parent_article.language_id
+        if origin_language_id and self.language_id and origin_language_id != self.language_id:
+            result_dict["is_translated"] = True
+
         if self.authors:
             result_dict["authors"] = self.authors
         elif self.uploader:

--- a/zeeguu/core/model/article_upload.py
+++ b/zeeguu/core/model/article_upload.py
@@ -39,6 +39,13 @@ class ArticleUpload(db.Model):
     language_id = Column(Integer, ForeignKey(Language.id), nullable=False)
     language = relationship(Language)
 
+    # The canonical article at this upload's URL (many uploads : one article).
+    # NULL until an article exists at the URL. The full body stays HERE, in the
+    # upload — it is never written into `article` (which may be recommended),
+    # so one subscriber's paywall access can't leak into the corpus.
+    article_id = Column(Integer, ForeignKey("article.id"), nullable=True)
+    article = relationship("Article", foreign_keys=[article_id])
+
     title = Column(String(512))
     raw_html = Column(UnicodeText())
     text_content = Column(UnicodeText())
@@ -65,6 +72,38 @@ class ArticleUpload(db.Model):
     @classmethod
     def find_by_id(cls, upload_id):
         return cls.query.filter_by(id=upload_id).first()
+
+    def canonical_article(self, session, create=False):
+        """The canonical Article at this upload's URL, linking it if needed.
+
+        This is the *handle* the reader/share stack consumes — NOT where the
+        full body lives (that stays in ``text_content`` here). We resolve it by
+        URL, and when ``create`` we build a public article FROM THE URL ONLY —
+        never from this upload's ``text_content``/``raw_html`` — so a
+        subscriber's full paywalled body is never laundered into a row that the
+        recommender could serve. A common crawl stub at the URL is the correct
+        handle; the recipient's full-body derivative is generated separately
+        from ``text_content``.
+
+        Returns the Article (and caches it on ``article_id``), or ``None`` if
+        no article exists and ``create`` is False.
+        """
+        from zeeguu.core.model.article import Article
+
+        if self.article is not None:
+            return self.article
+
+        url_string = self.url.as_string()
+        existing = Article.find(url_string)
+        if existing is None and create:
+            # URL only — deliberately no text_content/raw_html (see docstring).
+            existing = Article.find_or_create(session, url_string)
+
+        if existing is not None:
+            self.article_id = existing.id
+            session.add(self)
+            session.commit()
+        return existing
 
     @classmethod
     def for_user(cls, user, limit=_DEFAULT_USER_UPLOADS_LIMIT):
@@ -100,6 +139,8 @@ class ArticleUpload(db.Model):
             existing.language = language
             session.add(existing)
             session.commit()
+            # Link to a crawl already at this URL, if any (cheap — never creates).
+            existing.canonical_article(session, create=False)
             return existing
 
         upload = cls(
@@ -114,6 +155,8 @@ class ArticleUpload(db.Model):
         )
         session.add(upload)
         session.commit()
+        # Link to a crawl already at this URL, if any (cheap — never creates).
+        upload.canonical_article(session, create=False)
         return upload
 
     def as_dictionary(self):

--- a/zeeguu/core/model/shared_article.py
+++ b/zeeguu/core/model/shared_article.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import relationship
 from zeeguu.core.model.db import db
 from zeeguu.core.model.user import User
 from zeeguu.core.model.article import Article
+from zeeguu.core.model.language import Language
 
 
 class SharedArticle(db.Model):
@@ -24,6 +25,10 @@ class SharedArticle(db.Model):
     from_user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
     to_user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
     article_id = Column(Integer, ForeignKey("article.id"), nullable=False)
+    # The recipient's personalized copy ("the multiplexer out"): the language
+    # they receive it in, and the generated derivative (NULL until it's ready).
+    delivery_language_id = Column(Integer, ForeignKey("language.id"), nullable=True)
+    delivery_article_id = Column(Integer, ForeignKey("article.id"), nullable=True)
     note = Column(String(500), nullable=True)
     created_at = Column(DateTime, default=func.now())
     read_at = Column(DateTime, nullable=True)
@@ -32,12 +37,17 @@ class SharedArticle(db.Model):
     from_user = relationship(User, foreign_keys=[from_user_id])
     to_user = relationship(User, foreign_keys=[to_user_id])
     article = relationship(Article, foreign_keys=[article_id])
+    delivery_article = relationship(Article, foreign_keys=[delivery_article_id])
+    delivery_language = relationship(Language, foreign_keys=[delivery_language_id])
 
-    def __init__(self, from_user_id: int, to_user_id: int, article_id: int, note: str = None):
+    def __init__(self, from_user_id: int, to_user_id: int, article_id: int, note: str = None,
+                 delivery_language_id: int = None, delivery_article_id: int = None):
         self.from_user_id = from_user_id
         self.to_user_id = to_user_id
         self.article_id = article_id
         self.note = note
+        self.delivery_language_id = delivery_language_id
+        self.delivery_article_id = delivery_article_id
 
     @staticmethod
     def resolve_original_article_id(article) -> int:
@@ -64,9 +74,87 @@ class SharedArticle(db.Model):
 
         return article.id
 
+    @staticmethod
+    def resolve_shareable_original_id(session, article) -> int:
+        """The id of the canonical article to store on a share.
+
+        A share always points at the ONE canonical article — the real crawled
+        row at the publisher URL, which is the reader/inbox handle. The
+        recipient's full-body derivative is generated separately from the
+        sharer's upload (``source_upload.text_content``); this method only
+        resolves the handle and never writes a body anywhere.
+
+          - **Upload-based copy** (carries ``source_upload_id``): the canonical
+            article at the upload's URL, created from the URL if none exists yet
+            — NEVER from the upload's body (that would launder paywalled text
+            into a recommendable row). Falls back to the sharer's own article if
+            a handle can't be built, so the share still goes through.
+          - **Simplification of a crawl** (``parent_article_id``): its parent
+            (which may itself be upload-based → resolve through it).
+          - **Plain crawled original**: itself.
+
+        Always falls back to :meth:`resolve_original_article_id` on any error,
+        so a share never fails on a resolution edge case.
+
+        See docs/future-work/article-body-provenance-and-sharing.md.
+        """
+        try:
+            if article.source_upload_id and article.source_upload is not None:
+                canonical = article.source_upload.canonical_article(session, create=True)
+                if canonical is not None:
+                    return canonical.id
+                # No handle could be built — share the sharer's copy, don't fail.
+                return article.id
+
+            if article.parent_article_id:
+                parent = Article.find_by_id(article.parent_article_id)
+                if parent is not None:
+                    return SharedArticle.resolve_shareable_original_id(session, parent)
+                return article.parent_article_id
+
+            return SharedArticle.resolve_original_article_id(article)
+        except Exception as e:
+            from zeeguu.logging import log
+
+            log(
+                f"resolve_shareable_original_id: falling back for article "
+                f"{getattr(article, 'id', '?')}: {e}"
+            )
+            return SharedArticle.resolve_original_article_id(article)
+
+    @staticmethod
+    def compute_delivery_language(recipient, upload):
+        """The (language, cefr_level) the recipient's copy is delivered in.
+
+        The recipient's own profile decides it — never the sender:
+
+          - the article's **source language if the recipient learns it**
+            (→ simplify to their level; authentic text), else
+          - the recipient's **primary learned language** (→ translate + adapt).
+
+        Level is resolved for the chosen language, defaulting to A2 when the
+        recipient has no declared level there yet.
+        """
+        from zeeguu.core.model.user_language import UserLanguage
+
+        source_language = upload.language
+        delivery_language = recipient.learned_language
+        if source_language is not None:
+            learned = UserLanguage.all_languages_for_user(recipient)
+            if any(l.id == source_language.id for l in learned):
+                delivery_language = source_language
+
+        try:
+            level = recipient.cefr_level_for_language(delivery_language)
+        except Exception:
+            level = "A2"
+        return delivery_language, level
+
     @classmethod
-    def create(cls, session, from_user_id: int, to_user_id: int, article_id: int, note: str = None):
-        shared = cls(from_user_id, to_user_id, article_id, note)
+    def create(cls, session, from_user_id: int, to_user_id: int, article_id: int, note: str = None,
+               delivery_language_id: int = None, delivery_article_id: int = None):
+        shared = cls(from_user_id, to_user_id, article_id, note,
+                     delivery_language_id, delivery_article_id)
         session.add(shared)
         session.commit()
         return shared
@@ -106,6 +194,11 @@ class SharedArticle(db.Model):
         session.commit()
 
     def to_dict(self):
+        # Show (and open) the recipient's personalized derivative once it's
+        # ready — its title is in the recipient's language, and its parent_url
+        # still points at the publisher for "See original". Until then, fall
+        # back to the canonical article so the row isn't empty.
+        display_article = self.delivery_article or self.article
         return {
             "id": self.id,
             "from_user_id": self.from_user_id,
@@ -114,5 +207,13 @@ class SharedArticle(db.Model):
             "note": self.note,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "read": self.read_at is not None,
-            "article": self.article.article_info(with_content=False),
+            "article": display_article.article_info(with_content=False),
+            "delivery_ready": self.delivery_article_id is not None,
+            "delivery_language": self.delivery_language.code if self.delivery_language else None,
+            # Cross-language delivery → "Translated & simplified" vs "Simplified".
+            "translated": bool(
+                self.delivery_article
+                and self.article
+                and self.delivery_article.language_id != self.article.language_id
+            ),
         }

--- a/zeeguu/core/model/shared_article.py
+++ b/zeeguu/core/model/shared_article.py
@@ -210,10 +210,4 @@ class SharedArticle(db.Model):
             "article": display_article.article_info(with_content=False),
             "delivery_ready": self.delivery_article_id is not None,
             "delivery_language": self.delivery_language.code if self.delivery_language else None,
-            # Cross-language delivery → "Translated & simplified" vs "Simplified".
-            "translated": bool(
-                self.delivery_article
-                and self.article
-                and self.delivery_article.language_id != self.article.language_id
-            ),
         }

--- a/zeeguu/core/test/test_article_info_flags.py
+++ b/zeeguu/core/test/test_article_info_flags.py
@@ -1,0 +1,60 @@
+"""article_info exposes is_translated (cross-language) distinctly from
+is_simplified (same-language level adaptation). Derived by comparing the
+article's language to its origin's — see article-body-provenance-and-sharing.md.
+"""
+from unittest import TestCase
+
+from zeeguu.core.test.model_test_mixin import ModelTestMixIn
+from zeeguu.core.test.rules.article_rule import ArticleRule
+from zeeguu.core.test.rules.user_rule import UserRule
+from zeeguu.core.test.rules.language_rule import LanguageRule
+from zeeguu.core.test.rules.url_rule import UrlRule
+
+import zeeguu.core
+from zeeguu.core.model.article_upload import ArticleUpload
+
+session = zeeguu.core.model.db.session
+
+
+class ArticleInfoTranslatedFlagTest(ModelTestMixIn, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = UserRule().user
+        self.article = ArticleRule().article
+
+    def _upload_in(self, language):
+        upload = ArticleUpload(
+            user=self.user, url=UrlRule().url, language=language,
+            title="t", text_content="body",
+        )
+        session.add(upload)
+        session.commit()
+        return upload
+
+    def _other_language_than(self, language_id):
+        lang = LanguageRule().random
+        while lang.id == language_id:
+            lang = LanguageRule().random
+        return lang
+
+    def test_is_translated_when_language_differs_from_origin(self):
+        source_language = self.article.language
+        target_language = self._other_language_than(source_language.id)
+        upload = self._upload_in(source_language)
+
+        self.article.source_upload_id = upload.id
+        self.article.language = target_language  # "translated" into another language
+        session.add(self.article)
+        session.commit()
+
+        info = self.article.article_info(with_content=False)
+        assert info.get("is_translated") is True
+
+    def test_not_translated_when_same_language_as_origin(self):
+        upload = self._upload_in(self.article.language)
+        self.article.source_upload_id = upload.id
+        session.add(self.article)
+        session.commit()
+
+        info = self.article.article_info(with_content=False)
+        assert not info.get("is_translated")

--- a/zeeguu/core/test/test_shared_article_delivery.py
+++ b/zeeguu/core/test/test_shared_article_delivery.py
@@ -1,0 +1,58 @@
+"""The recipient decides the delivery language — never the sender.
+
+Source language if the recipient learns it (→ simplify in it); otherwise their
+primary learned language (→ translate + adapt). See
+docs/future-work/article-body-provenance-and-sharing.md.
+"""
+from unittest import TestCase
+
+from zeeguu.core.test.model_test_mixin import ModelTestMixIn
+from zeeguu.core.test.rules.user_rule import UserRule
+from zeeguu.core.test.rules.language_rule import LanguageRule
+
+import zeeguu.core
+from zeeguu.core.model.shared_article import SharedArticle
+from zeeguu.core.model.user_language import UserLanguage
+
+session = zeeguu.core.model.db.session
+
+
+class _Upload:
+    """Minimal stand-in — compute_delivery_language only reads .language."""
+
+    def __init__(self, language):
+        self.language = language
+
+
+def _language_other_than(*language_ids):
+    lang = LanguageRule().random
+    while lang.id in language_ids:
+        lang = LanguageRule().random
+    return lang
+
+
+class SharedArticleDeliveryLanguageTest(ModelTestMixIn, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.recipient = UserRule().user
+
+    def test_source_language_when_recipient_learns_it(self):
+        # A second language the recipient learns (not their primary).
+        lang2 = _language_other_than(self.recipient.learned_language_id)
+        UserLanguage.find_or_create(session, self.recipient, lang2)
+
+        delivery, level = SharedArticle.compute_delivery_language(
+            self.recipient, _Upload(lang2)
+        )
+        # Delivered in the article's own language, since the recipient learns it.
+        assert delivery.id == lang2.id
+        assert level in ("A1", "A2", "B1", "B2", "C1", "C2")
+
+    def test_falls_back_to_primary_when_source_not_learned(self):
+        foreign = _language_other_than(self.recipient.learned_language_id)
+
+        delivery, _ = SharedArticle.compute_delivery_language(
+            self.recipient, _Upload(foreign)
+        )
+        # Recipient doesn't learn the source language → their primary.
+        assert delivery.id == self.recipient.learned_language_id

--- a/zeeguu/core/test/test_shared_article_resolution.py
+++ b/zeeguu/core/test/test_shared_article_resolution.py
@@ -1,0 +1,88 @@
+"""Resolving what a friend-share points at (the canonical article handle).
+
+Core rule (docs/future-work/article-body-provenance-and-sharing.md): a share of
+an upload-based copy resolves to the ONE canonical article at the publisher URL
+— never a new synthetic row, and never by writing the upload's full body into a
+recommendable article. The full body stays in the upload; only the handle is
+resolved here.
+"""
+from unittest import TestCase
+
+from zeeguu.core.test.model_test_mixin import ModelTestMixIn
+from zeeguu.core.test.rules.article_rule import ArticleRule
+from zeeguu.core.test.rules.user_rule import UserRule
+
+import zeeguu.core
+from zeeguu.core.model.article import Article
+from zeeguu.core.model.article_upload import ArticleUpload
+from zeeguu.core.model.shared_article import SharedArticle
+
+session = zeeguu.core.model.db.session
+
+
+class SharedArticleResolutionTest(ModelTestMixIn, TestCase):
+    def setUp(self):
+        super().setUp()
+        # A crawl stub sitting at a publisher URL — possibly a paywalled teaser.
+        self.stub = ArticleRule().article
+        self.publisher_url = self.stub.url.as_string()
+        self.user = UserRule().user
+
+    def _upload_at_stub_url(self, user, full_body="The COMPLETE article body."):
+        return ArticleUpload.find_or_create(
+            session,
+            user=user,
+            url_string=self.publisher_url,
+            raw_html=None,
+            text_content=full_body,
+            title=self.stub.title,
+            language_code=self.stub.language.code,
+        )
+
+    def test_upload_links_to_existing_crawl_at_creation(self):
+        upload = self._upload_at_stub_url(self.user)
+        # find_or_create links to the crawl already at the URL — no new article.
+        assert upload.article_id == self.stub.id
+
+    def test_share_of_upload_copy_resolves_to_canonical_stub(self):
+        upload = self._upload_at_stub_url(self.user)
+
+        # The sharer's copy: a derivative carrying source_upload_id (as the
+        # send-and-simplify path produces today). We don't need a real
+        # simplification here — only that it points at the upload.
+        sharer_copy = ArticleRule().article
+        sharer_copy.source_upload_id = upload.id
+        session.add(sharer_copy)
+        session.commit()
+
+        resolved = SharedArticle.resolve_shareable_original_id(session, sharer_copy)
+
+        # Resolves to the canonical stub — NOT the sharer's own copy, and NOT a
+        # freshly minted synthetic row.
+        assert resolved == self.stub.id
+        assert resolved != sharer_copy.id
+
+    def test_two_uploaders_same_url_share_one_canonical_article(self):
+        other = UserRule().user
+        upload_a = self._upload_at_stub_url(self.user, "Full body (subscriber).")
+        upload_b = self._upload_at_stub_url(other, "Teaser only (no sub).")
+        assert upload_a.id != upload_b.id
+        # Many uploads : one article.
+        assert upload_a.article_id == self.stub.id
+        assert upload_b.article_id == self.stub.id
+
+    def test_plain_crawl_resolves_to_itself(self):
+        assert (
+            SharedArticle.resolve_shareable_original_id(session, self.stub)
+            == self.stub.id
+        )
+
+    def test_simplification_of_crawl_resolves_to_parent(self):
+        child = ArticleRule().article
+        child.parent_article_id = self.stub.id
+        session.add(child)
+        session.commit()
+        assert (
+            SharedArticle.resolve_shareable_original_id(session, child)
+            == self.stub.id
+        )


### PR DESCRIPTION
## What

Evolve friend-sharing so a shared article arrives **personalized for the recipient** — their language, at their level — generated from the full body the sharer captured, not the sharer's own adapted copy and not a paywalled crawl stub. "Send an article that was personalized for me, and it arrives to my friend personalized for him."

Fixes the resolution bug the draft #689 exposed, on a corrected model.

## The model

Settled in [`docs/future-work/article-body-provenance-and-sharing.md`](https://github.com/zeeguu/api/blob/wt/friend-share-original/../docs/future-work/article-body-provenance-and-sharing.md) (docs repo):

- **One `article` per URL.** The upload↔article FK flips onto `article_upload.article_id` (**many uploads : one article**), correcting `article.source_upload_id`'s direction — a URL can be uploaded by many users (a subscriber captures the full body, a non-subscriber only the teaser). The full body stays in the per-user upload; it is **never written into a recommendable `article`** (no paywall laundering). `article.source_upload_id` is left in place during the transition.
- **Resolve-for-share** → the canonical article at the upload's URL (the reader/inbox handle + "See original"). Never a synthetic row, never the sharer's copy.
- **The recipient decides the language** — never the sender: the source language if they learn it (→ simplify), else their primary learned language (→ translate + adapt). Level per (recipient, language).
- **Generated at send time, in the background**, creating the share row **last** so it appears in the inbox only once the recipient's copy is ready (no not-ready window; Send stays instant).

## Changes

- Migrations: `article_upload.article_id` (+ backfill), `shared_article.delivery_{language,article}_id`
- `ArticleUpload.canonical_article()` + auto-link on upload
- `SharedArticle.resolve_shareable_original_id`, `compute_delivery_language`
- `create_recipient_derivative` — same-language simplify / cross-language translate, cached per (upload, language, level)
- `share_article_with_friend`: background resolve → generate → create row → email
- 7 tests (resolution + delivery-language)

## Deploy

Run the two migrations, then deploy. **Deploy before the web PR** (web reads the new inbox payload fields). Recipient-facing behavior only changes for **upload-based** shares; plain-crawl shares keep today's open-and-adapt-in-reader.

## Follow-ups (not here)

- Retire `article.source_upload_id` once `article_info.parent_url` and the send-and-simplify child move onto `parent_article_id`.
- Recipient header attribution lives in the paired web PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
