### PR TITLE
Friend-share: route to recipient's primary language; always stamp delivery_language

### DIFF
--- a/zeeguu/api/endpoints/friends.py
+++ b/zeeguu/api/endpoints/friends.py
@@ -460,7 +460,17 @@ def _deliver_share(from_user_id: int, to_user_id: int, article_id: int, note):
         return
 
     original_id = SharedArticle.resolve_shareable_original_id(db.session, article)
-    delivery_language_id, delivery_article_id = _recipient_derivative_for(article, recipient)
+
+    # Route the share by the recipient's primary language — ALWAYS, even for a
+    # plain crawl share that gets no derivative — so it's the "which inbox" key
+    # and the per-language inbox surfaces it in the language they actually study.
+    delivery_language, level = SharedArticle.compute_delivery_language(recipient)
+    delivery_language_id = delivery_language.id if delivery_language is not None else None
+    delivery_article_id = (
+        _generate_recipient_derivative(article, recipient, delivery_language, level)
+        if delivery_language is not None
+        else None
+    )
 
     shared = SharedArticle.create(
         db.session, from_user_id, to_user_id, original_id, note,
@@ -476,39 +486,37 @@ def _deliver_share(from_user_id: int, to_user_id: int, article_id: int, note):
         log(f"share {shared.id}: email notification failed: {e}")
 
 
-def _recipient_derivative_for(article, recipient):
-    """(delivery_language_id, delivery_article_id) for a share of `article` to
-    `recipient`. Returns (None, None) for a plain crawl share (no upload body),
-    and (language_id, None) if generation fails — the recipient then opens the
-    canonical article and adapts it in the reader, so a share never fails."""
+def _generate_recipient_derivative(article, recipient, delivery_language, level):
+    """The id of the recipient's personalized derivative, or None.
+
+    Only for upload-based shares (the sharer captured a full body); plain crawl
+    shares get None and the recipient opens the canonical article (adapting it
+    in the reader). Never raises — a generation failure (LLM/fragment/DB) rolls
+    back and degrades to None so the share still lands, routed by its language.
+    """
+    upload = article.source_upload
+    if upload is None:
+        return None
+
     from zeeguu.core.llm_services.simplification_and_classification import (
         create_recipient_derivative,
     )
 
-    upload = article.source_upload
-    if upload is None:
-        return None, None
-
-    # Never let a generation failure drop the share: _deliver_share creates the
-    # row AFTER this, so any exception raised here would skip row creation
-    # entirely (recipient with no learned_language, fragment/LLM/DB error, …).
-    # Degrade to "no derivative" — the recipient opens the canonical article and
-    # adapts it in the reader — and roll back so the dirty session doesn't taint
-    # the subsequent row commit.
     try:
-        delivery_language, level = SharedArticle.compute_delivery_language(recipient, upload)
-        derivative = create_recipient_derivative(db.session, upload, delivery_language.code, level)
+        derivative = create_recipient_derivative(
+            db.session, upload, delivery_language.code, level
+        )
     except Exception as e:
         db.session.rollback()
         log(f"share to user_id={recipient.id}: derivative generation errored "
             f"({e}); recipient will open the canonical article")
-        return None, None
+        return None
 
     if derivative is None:
         log(f"share to user_id={recipient.id}: derivative generation failed; "
             f"recipient will open the canonical article")
-        return delivery_language.id, None
-    return delivery_language.id, derivative.id
+        return None
+    return derivative.id
 
 
 # ---------------------------------------------------------------------------

--- a/zeeguu/core/model/shared_article.py
+++ b/zeeguu/core/model/shared_article.py
@@ -123,27 +123,23 @@ class SharedArticle(db.Model):
             return SharedArticle.resolve_original_article_id(article)
 
     @staticmethod
-    def compute_delivery_language(recipient, upload):
-        """The (language, cefr_level) the recipient's copy is delivered in.
+    def compute_delivery_language(recipient):
+        """The (language, cefr_level) the recipient's copy is delivered in —
+        always their primary/active learned language (``learned_language``).
 
-        The recipient's own profile decides it — never the sender:
+        If the article's source language IS that language it's simplified in
+        place (authentic text); otherwise it's translated + adapted into it.
+        We deliberately do NOT route into a merely-also-studied secondary
+        language: a German-A1 dabbler shouldn't receive a German article just
+        because German is on their list — it lands in the language they actually
+        study, where their per-language inbox surfaces it. (They can still switch
+        to a secondary in the reader to read it authentically, generated on
+        demand.)
 
-          - the article's **source language if the recipient learns it**
-            (→ simplify to their level; authentic text), else
-          - the recipient's **primary learned language** (→ translate + adapt).
-
-        Level is resolved for the chosen language, defaulting to A2 when the
-        recipient has no declared level there yet.
+        Level is resolved for that language, defaulting to A2 when the recipient
+        has no declared level there yet.
         """
-        from zeeguu.core.model.user_language import UserLanguage
-
-        source_language = upload.language
         delivery_language = recipient.learned_language
-        if source_language is not None:
-            learned = UserLanguage.all_languages_for_user(recipient)
-            if any(l.id == source_language.id for l in learned):
-                delivery_language = source_language
-
         try:
             level = recipient.cefr_level_for_language(delivery_language)
         except Exception:

--- a/zeeguu/core/test/test_shared_article_delivery.py
+++ b/zeeguu/core/test/test_shared_article_delivery.py
@@ -1,7 +1,5 @@
-"""The recipient decides the delivery language — never the sender.
-
-Source language if the recipient learns it (→ simplify in it); otherwise their
-primary learned language (→ translate + adapt). See
+"""The recipient's copy is delivered in their PRIMARY/active learned language —
+never routed into a merely-also-studied secondary. See
 docs/future-work/article-body-provenance-and-sharing.md.
 """
 from unittest import TestCase
@@ -17,42 +15,28 @@ from zeeguu.core.model.user_language import UserLanguage
 session = zeeguu.core.model.db.session
 
 
-class _Upload:
-    """Minimal stand-in — compute_delivery_language only reads .language."""
-
-    def __init__(self, language):
-        self.language = language
-
-
-def _language_other_than(*language_ids):
-    lang = LanguageRule().random
-    while lang.id in language_ids:
-        lang = LanguageRule().random
-    return lang
-
-
 class SharedArticleDeliveryLanguageTest(ModelTestMixIn, TestCase):
     def setUp(self):
         super().setUp()
         self.recipient = UserRule().user
 
-    def test_source_language_when_recipient_learns_it(self):
-        # A second language the recipient learns (not their primary).
-        lang2 = _language_other_than(self.recipient.learned_language_id)
-        UserLanguage.find_or_create(session, self.recipient, lang2)
+    def _language_other_than(self, language_id):
+        lang = LanguageRule().random
+        while lang.id == language_id:
+            lang = LanguageRule().random
+        return lang
 
-        delivery, level = SharedArticle.compute_delivery_language(
-            self.recipient, _Upload(lang2)
-        )
-        # Delivered in the article's own language, since the recipient learns it.
-        assert delivery.id == lang2.id
+    def test_delivers_in_primary_language(self):
+        delivery, level = SharedArticle.compute_delivery_language(self.recipient)
+        assert delivery.id == self.recipient.learned_language_id
         assert level in ("A1", "A2", "B1", "B2", "C1", "C2")
 
-    def test_falls_back_to_primary_when_source_not_learned(self):
-        foreign = _language_other_than(self.recipient.learned_language_id)
+    def test_does_not_route_into_a_studied_secondary_language(self):
+        # The recipient also studies a second language — a share must still be
+        # delivered in their primary, not hijacked into the secondary.
+        secondary = self._language_other_than(self.recipient.learned_language_id)
+        UserLanguage.find_or_create(session, self.recipient, secondary)
 
-        delivery, _ = SharedArticle.compute_delivery_language(
-            self.recipient, _Upload(foreign)
-        )
-        # Recipient doesn't learn the source language → their primary.
+        delivery, _ = SharedArticle.compute_delivery_language(self.recipient)
         assert delivery.id == self.recipient.learned_language_id
+        assert delivery.id != secondary.id


### PR DESCRIPTION
Follow-up to #690.

- `compute_delivery_language` now always returns the recipient's primary/active learned language. The old "source language if they study it at all" rule mis-routed — a German-A1 dabbler received a German article delivered in German instead of their real study language. A secondary no longer hijacks delivery.
- Every share is stamped with `delivery_language` (upload or plain crawl), so it's the reliable per-language-inbox key; derivative generation is separate and upload-only, and never blocks the language stamp.

Enables the web per-language inbox filter (zeeguu/web#1203) to be strict. Deploy before that web change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)