### PR TITLE
Friend-share: warm tokenization cache at send for instant recipient open

### DIFF
--- a/zeeguu/api/endpoints/friends.py
+++ b/zeeguu/api/endpoints/friends.py
@@ -516,6 +516,17 @@ def _generate_recipient_derivative(article, recipient, delivery_language, level)
         log(f"share to user_id={recipient.id}: derivative generation failed; "
             f"recipient will open the canonical article")
         return None
+
+    # Warm the reader's tokenization cache now, in this same background job, so
+    # the recipient's first open is instant instead of paying the Stanza/MWE
+    # tokenization cost then. get_tokenized_content() caches on a miss. Best
+    # effort — a warm-up failure must not fail the share.
+    try:
+        derivative.get_tokenized_content()
+    except Exception as e:
+        log(f"share to user_id={recipient.id}: tokenization warm-up failed "
+            f"(non-fatal): {e}")
+
     return derivative.id
 
 


### PR DESCRIPTION
Follow-up to #690/#691. The recipient's derivative is generated in the background at send time; this warms its Stanza/MWE tokenization cache in the same job (`get_tokenized_content()` caches on a miss), so the recipient's first open is instant rather than paying tokenization then. Best-effort — a warm-up failure never fails the share. api-only, no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)